### PR TITLE
Allow upstreams, policies, and externcal connections on Create.

### DIFF
--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -37,6 +37,26 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 2048
+    },
+    "ExternalConnections": {
+      "description": "An array of external connections associated with the repository.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "Upstreams": {
+      "description": "A list of upstream repositories to associate with the repository.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "PolicyDocument": {
+      "description": "The access control resource policy on the provided repository.",
+      "type": "object",
+      "minLength": 2,
+      "maxLength": 5120
     }
   },
   "additionalProperties": false,

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
@@ -1,8 +1,22 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.amazonaws.util.CollectionUtils;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionResponse;
+import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
+import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -30,4 +44,83 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     final CallbackContext callbackContext,
     final ProxyClient<CodeartifactClient> proxyClient,
     final Logger logger);
+
+  protected ProgressEvent<ResourceModel, CallbackContext> associateExternalConnections(
+      final ProgressEvent<ResourceModel, CallbackContext> progress,
+      final CallbackContext callbackContext,
+      final ResourceHandlerRequest<ResourceModel> request,
+      final ProxyClient<CodeartifactClient> proxyClient,
+      final Set<String> externalConnectionsToAdd,
+      final Logger logger
+  ) {
+      ResourceModel resourceModel = request.getDesiredResourceState();
+
+      if (CollectionUtils.isNullOrEmpty(externalConnectionsToAdd)) {
+          // Nothing to add, continue
+          return ProgressEvent.progress(resourceModel, callbackContext);
+      }
+
+      if (externalConnectionsToAdd.size() > 1) {
+          return ProgressEvent.failed(resourceModel, callbackContext, HandlerErrorCode.InvalidRequest,
+              "ExternalConnections for repositories are currently limited to 1.");
+      }
+
+      // Loop is currently not necessary because only 1 external connection is allowed, leaving this in for
+      // when multiple are supported
+      externalConnectionsToAdd.forEach(ec -> {
+          try {
+              AssociateExternalConnectionRequest associateExternalConnectionRequest
+                  = Translator.translateAssociateExternalConnectionsRequest(resourceModel, ec);
+
+              proxyClient.injectCredentialsAndInvokeV2(associateExternalConnectionRequest, proxyClient.client()::associateExternalConnection);
+          } catch (final AwsServiceException e) {
+              String repositoryName = progress.getResourceModel().getRepositoryName();
+              Translator.throwCfnException(e, Constants.ASSOCIATE_EXTERNAL_CONNECTION, repositoryName);
+          }
+          logger.log(String.format("Successfully associated external connection: %s", ec));
+      });
+
+      return ProgressEvent.<ResourceModel, CallbackContext>builder()
+          .resourceModel(resourceModel)
+          .status(OperationStatus.IN_PROGRESS)
+          .build();
+  }
+
+  protected ProgressEvent<ResourceModel, CallbackContext> putRepositoryPermissionsPolicy(
+      final AmazonWebServicesClientProxy proxy,
+      final ProgressEvent<ResourceModel, CallbackContext> progress,
+      final CallbackContext callbackContext,
+      final ProxyClient<CodeartifactClient> proxyClient,
+      final Logger logger
+  ) {
+      final ResourceModel desiredModel = progress.getResourceModel();
+      if (desiredModel.getPolicyDocument() == null) {
+          return ProgressEvent.progress(desiredModel, callbackContext);
+      }
+      return proxy.initiate("AWS-CodeArtifact-Repository::Update::PutRepositoryPermissionsPolicy", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+          .translateToServiceRequest(Translator::translatePutPermissionsPolicyRequest)
+          .makeServiceCall((awsRequest, client) -> {
+              PutRepositoryPermissionsPolicyResponse awsResponse = null;
+              try {
+                  awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, client.client()::putRepositoryPermissionsPolicy);
+                  logger.log("Repository permission policy successfully added.");
+              } catch (final AwsServiceException e) {
+                  String domainName = desiredModel.getDomainName();
+                  Translator.throwCfnException(e, Constants.PUT_REPOSITORY_POLICY, domainName);
+              }
+              return awsResponse;
+          })
+          .stabilize((awsRequest, awsResponse, client, model, context) -> policyIsStabilized(model, client))
+          .progress();
+  }
+
+  private boolean policyIsStabilized(final ResourceModel model, final ProxyClient<CodeartifactClient> proxyClient) {
+      try {
+          proxyClient.injectCredentialsAndInvokeV2(Translator.translateToGetRepositoryPermissionsPolicy(model), proxyClient.client()::getRepositoryPermissionsPolicy);
+          return true;
+      } catch (ResourceNotFoundException e) {
+          return false;
+      }
+  }
+
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
@@ -4,4 +4,8 @@ public class Constants {
     public static final String CREATE_REPOSITORY = "codeartifact::CreateRepository";
     public static final String DESCRIBE_REPOSITORY = "codeartifact::DescribeRepository";
     public static final String DELETE_REPOSITORY = "codeartifact::DeleteRepository";
+    public static final String PUT_REPOSITORY_POLICY = "codeartifact::PutRepositoryPermissionPolicy";
+    public static final String ASSOCIATE_EXTERNAL_CONNECTION = "codeartifact::AssociateExternalConnection";
+    public static final String DISASSOCIATE_EXTERNAL_CONNECTION = "codeartifact::DisassociateExternalConnection";
+
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
@@ -1,9 +1,9 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Set;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
-import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -24,36 +24,36 @@ public class CreateHandler extends BaseHandlerStd {
         final Logger logger) {
 
         this.logger = logger;
+        ResourceModel model = request.getDesiredResourceState();
+        final Set<String> externalConnectionsToAdd = Translator.translateExternalConnectionFromDesiredResource(model);
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-            // STEP 1 [create/stabilize progress chain - required for resource creation]
-            .then(progress ->
-                proxy.initiate("AWS-CodeArtifact-Domain::Create", proxyClient,progress.getResourceModel(), progress.getCallbackContext())
-                    .translateToServiceRequest(Translator::translateToCreateRequest)
-                    .makeServiceCall((awsRequest, client) -> createRepository(progress, client, awsRequest))
-                    .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client))
-                    .progress()
-            )
-            // STEP 2 [describe call/chain to return the resource model]
+            .then(progress -> createRepository(proxy, progress, proxyClient))
+            .then(progress -> putRepositoryPermissionsPolicy(proxy, progress, callbackContext, proxyClient, logger))
+            .then(progress -> associateExternalConnections(progress, callbackContext, request, proxyClient, externalConnectionsToAdd, logger))
             .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 
-    private AwsResponse createRepository(
-        ProgressEvent<ResourceModel, CallbackContext>  progress,
-        ProxyClient<CodeartifactClient> client,
-        CreateRepositoryRequest awsRequest
+    private ProgressEvent<ResourceModel, CallbackContext> createRepository(
+        AmazonWebServicesClientProxy proxy,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
+        ProxyClient<CodeartifactClient> proxyClient
     ) {
-        AwsResponse awsResponse = null;
-        try {
-            awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, client.client()::createRepository);
-        } catch (final AwsServiceException e) {
-            String repositoryName = progress.getResourceModel().getRepositoryName();
-            Translator.throwCfnException(e, Constants.CREATE_REPOSITORY, repositoryName);
-        }
-
-        // TODO Add Policy, Upstream, ExternalConnections if provided
-        logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+        return proxy.initiate("AWS-CodeArtifact-Repository::Create", proxyClient,progress.getResourceModel(), progress.getCallbackContext())
+            .translateToServiceRequest(Translator::translateToCreateRequest)
+            .makeServiceCall((awsRequest, client) -> {
+                AwsResponse awsResponse = null;
+                try {
+                    awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, client.client()::createRepository);
+                } catch (final AwsServiceException e) {
+                    String repositoryName = progress.getResourceModel().getRepositoryName();
+                    Translator.throwCfnException(e, Constants.CREATE_REPOSITORY, repositoryName);
+                }
+                logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
+                return awsResponse;
+            })
+            .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client))
+            .progress();
     }
 
     private boolean isStabilized(

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -3,24 +3,35 @@ package software.amazon.codeartifact.repository;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.model.AccessDeniedException;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionRequest;
 import software.amazon.awssdk.services.codeartifact.model.ConflictException;
 import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryRequest;
+import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.DisassociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
+import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
+import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryRequest;
+import software.amazon.awssdk.services.codeartifact.model.UpstreamRepository;
+import software.amazon.awssdk.services.codeartifact.model.UpstreamRepositoryInfo;
 import software.amazon.awssdk.services.codeartifact.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
@@ -38,6 +49,7 @@ import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededExceptio
  */
 
 public class Translator {
+  public static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Request to create a resource
@@ -48,9 +60,37 @@ public class Translator {
     return CreateRepositoryRequest.builder()
         .domain(model.getDomainName())
         .domainOwner(model.getDomainOwner())
+        .upstreams(translateToUpstreamList(model))
         .repository(model.getRepositoryName())
         .description(model.getDescription())
         .build();
+  }
+
+  /**
+   * Translates ResourceModel upstream array into UpstreamRepository List
+   * @param model resource model
+   * @return list of UpstreamRepository
+   */
+  static List<UpstreamRepository> translateToUpstreamList(final ResourceModel model) {
+    return streamOfOrEmpty(model.getUpstreams())
+        .map(upstream -> UpstreamRepository.builder()
+            .repositoryName(upstream)
+            .build()
+        )
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Translates repositoryDescription to list of strings
+   * @param repositoryDescription repo description
+   * @return list of repository names
+   */
+  static List<String> translateToUpstreamsFromRepoDescription(
+      final RepositoryDescription repositoryDescription
+  ) {
+    return streamOfOrEmpty(repositoryDescription.upstreams())
+        .map(UpstreamRepositoryInfo::repositoryName)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -74,14 +114,63 @@ public class Translator {
   static ResourceModel translateFromReadResponse(final DescribeRepositoryResponse describeRepositoryResponse) {
     RepositoryDescription repositoryDescription = describeRepositoryResponse.repository();
     return ResourceModel.builder()
-        // TODO add external connections and upstreams to read response
+        // TODO add external connections and policy document
+        // https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-codeartifact/issues/18
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
         .administratorAccount(repositoryDescription.administratorAccount())
         .domainName(repositoryDescription.domainName())
+        .upstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()))
         .domainOwner(repositoryDescription.domainOwner())
         .description(repositoryDescription.description())
         .repositoryName(repositoryDescription.name())
+        .build();
+  }
+
+  /**
+   * Translates resource model into PutRepositoryPermissionsPolicyRequest
+   * @param resourceModel resource model
+   * @return PutRepositoryPermissionsPolicyRequest
+   */
+  public static PutRepositoryPermissionsPolicyRequest translatePutPermissionsPolicyRequest(
+      ResourceModel resourceModel
+  ) {
+    try {
+      return PutRepositoryPermissionsPolicyRequest.builder()
+          .domain(resourceModel.getDomainName())
+          .repository(resourceModel.getRepositoryName())
+          .domainOwner(resourceModel.getDomainOwner())
+          .policyDocument(MAPPER.writeValueAsString(resourceModel.getPolicyDocument()))
+          .build();
+    } catch (final JsonProcessingException e) {
+        throw new CfnInvalidRequestException(e);
+      }
+  }
+
+  /**
+   * Translates resource model into DeleteRepositoryPermissionsPolicyRequest
+   * @param resourceModel resource model
+   * @return DeleteRepositoryPermissionsPolicyRequest
+   */
+  public static DeleteRepositoryPermissionsPolicyRequest translateDeletePermissionsPolicyRequest(
+      ResourceModel resourceModel
+  ) {
+      return DeleteRepositoryPermissionsPolicyRequest.builder()
+          .domain(resourceModel.getDomainName())
+          .domainOwner(resourceModel.getDomainOwner())
+          .repository(resourceModel.getRepositoryName())
+          .build();
+  }
+
+  /**
+   * Request to describe repository permissions policy
+   * @param model resource model
+   * @return awsRequest the aws service request to describe a policy
+   */
+  static GetRepositoryPermissionsPolicyRequest translateToGetRepositoryPermissionsPolicy(final ResourceModel model) {
+    return GetRepositoryPermissionsPolicyRequest.builder()
+        .domain(model.getDomainName())
+        .domainOwner(model.getDomainOwner())
         .build();
   }
 
@@ -91,7 +180,7 @@ public class Translator {
    * @return awsRequest the aws service request to delete a resource
    */
   static DeleteRepositoryRequest translateToDeleteRequest(final ResourceModel model) {
-    return  DeleteRepositoryRequest.builder()
+    return DeleteRepositoryRequest.builder()
         .domain(model.getDomainName())
         .domainOwner(model.getDomainOwner())
         .repository(model.getRepositoryName())
@@ -99,26 +188,57 @@ public class Translator {
   }
 
   /**
-   * Request to update properties of a previously created resource
+   * Request to associate External Connection
    * @param model resource model
+   * @param  externalConnectionToAdd external connection to associate
    * @return awsRequest the aws service request to modify a resource
    */
-  static AwsRequest translateToFirstUpdateRequest(final ResourceModel model) {
-    final AwsRequest awsRequest = null;
-    // TODO: construct a request
-    // e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/blob/2077c92299aeb9a68ae8f4418b5e932b12a8b186/aws-logs-loggroup/src/main/java/com/aws/logs/loggroup/Translator.java#L45-L50
-    return awsRequest;
+  static AssociateExternalConnectionRequest translateAssociateExternalConnectionsRequest(
+      final ResourceModel model,
+      final String externalConnectionToAdd
+  ) {
+    return AssociateExternalConnectionRequest.builder()
+        .domain(model.getDomainName())
+        .repository(model.getRepositoryName())
+        .domainOwner(model.getDomainOwner())
+        .externalConnection(externalConnectionToAdd)
+        .build();
+  }
+
+  static Set<String> translateExternalConnectionFromDesiredResource(final ResourceModel model) {
+    return streamOfOrEmpty(model.getExternalConnections())
+        .collect(Collectors.toSet());
   }
 
   /**
-   * Request to update some other properties that could not be provisioned through first update request
+   * Request to remove External Connection from Repository
+   * @param model resource model
+   * @param externalConnectionToRemove External Connections to remove
+   * @return awsRequest the aws service request to modify a resource
+   */
+  static DisassociateExternalConnectionRequest translateDisassociateExternalConnectionsRequest(
+      final ResourceModel model,
+      final String externalConnectionToRemove
+  ) {
+    return DisassociateExternalConnectionRequest.builder()
+        .domain(model.getDomainName())
+        .domainOwner(model.getDomainOwner())
+        .externalConnection(externalConnectionToRemove)
+        .build();
+  }
+
+  /**
+   * Request to update Repository
    * @param model resource model
    * @return awsRequest the aws service request to modify a resource
    */
-  static AwsRequest translateToSecondUpdateRequest(final ResourceModel model) {
-    final AwsRequest awsRequest = null;
-    // TODO: construct a request
-    return awsRequest;
+  static UpdateRepositoryRequest translateToUpdateRepository(final ResourceModel model) {
+    return UpdateRepositoryRequest.builder()
+        .domain(model.getDomainName())
+        .domainOwner(model.getDomainOwner())
+        .description(model.getDescription())
+        .upstreams(translateToUpstreamList(model))
+        .build();
   }
 
   /**
@@ -148,7 +268,7 @@ public class Translator {
         .collect(Collectors.toList());
   }
 
-  private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+  public static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
     return Optional.ofNullable(collection)
         .map(Collection::stream)
         .orElseGet(Stream::empty);

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -1,5 +1,7 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.awscore.AwsRequest;
@@ -13,6 +15,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import org.apache.commons.collections.map.HashedMap;
 
 public class AbstractTestBase {
   protected static final String DOMAIN_NAME = "test-domain-name";
@@ -20,6 +23,8 @@ public class AbstractTestBase {
   protected static final String ADMIN_ACCOUNT = "54321";
   protected static final String REPO_ARN = "repoArn";
   protected static final String REPO_NAME = "test-repo-name";
+  protected static final Map<String, Object> TEST_POLICY_DOC = Collections.singletonMap("key", "value");
+  protected static final String TEST_POLICY_DOC_JSON = "{\"key\":\"value\"}";
   protected static final String DESCRIPTION = "repoDescription";
 
   protected static final Credentials MOCK_CREDENTIALS;

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.codeartifact.repository;
 
 import java.time.Duration;
+import java.util.Collections;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.ConflictException;
@@ -75,6 +76,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         .domainName(DOMAIN_NAME)
         .domainOwner(DOMAIN_OWNER)
         .arn(REPO_ARN)
+        .upstreams(Collections.emptyList())
         .repositoryName(REPO_NAME)
         .description(DESCRIPTION)
         .administratorAccount(ADMIN_ACCOUNT)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow for upstreams, external connections, and policies to be specified on Create

*Testing*
Using `cfn invoke CREATE` to create a repository with external connections and validated. 
Using `cfn invoke CREATE` to create a repository with upstreams and validated. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
