### PR TITLE
Update Handlers, External Connections, and Upstreams

### DIFF
--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -37,6 +37,26 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 2048
+    },
+    "ExternalConnections": {
+      "description": "An array of external connections associated with the repository.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "Upstreams": {
+      "description": "A list of upstream repositories to associate with the repository.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "PolicyDocument": {
+      "description": "The access control resource policy on the provided repository.",
+      "type": "object",
+      "minLength": 2,
+      "maxLength": 5120
     }
   },
   "additionalProperties": false,

--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -66,7 +66,7 @@
   ],
   "createOnlyProperties": [
     "/properties/RepositoryName",
-    "/properties/Description"
+    "/properties/DomainName"
   ],
   "readOnlyProperties": [
     "/properties/Arn",

--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -39,20 +39,20 @@
       "maxLength": 2048
     },
     "ExternalConnections": {
-      "description": "An array of external connections associated with the repository.",
+      "description": "A list of external connections associated with the repository.",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "Upstreams": {
-      "description": "A list of upstream repositories to associate with the repository.",
+      "description": "A list of upstream repositories associated with the repository.",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
-    "PolicyDocument": {
+    "PermissionsPolicyDocument": {
       "description": "The access control resource policy on the provided repository.",
       "type": "object",
       "minLength": 2,
@@ -66,11 +66,11 @@
   ],
   "createOnlyProperties": [
     "/properties/RepositoryName",
-    "/properties/DomainName"
+    "/properties/DomainName",
+    "/properties/DomainOwner"
   ],
   "readOnlyProperties": [
     "/properties/Arn",
-    "/properties/DomainOwner",
     "/properties/AdministratorAccount"
   ],
   "primaryIdentifier": [
@@ -81,7 +81,7 @@
       "permissions": [
         "codeartifact:CreateRepository",
         "codeartifact:DescribeRepository",
-        "codeartifact:PutRepositoryPermissionPolicy",
+        "codeartifact:PutRepositoryPermissionsPolicy",
         "codeartifact:AssociateExternalConnection"
       ]
     },

--- a/aws-codeartifact-repository/resource-role.yaml
+++ b/aws-codeartifact-repository/resource-role.yaml
@@ -23,13 +23,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "codeartifact:AssociateExternalConnection"
                 - "codeartifact:CreateRepository"
                 - "codeartifact:DeleteRepository"
                 - "codeartifact:DeleteRepositoryPermissionsPolicy"
                 - "codeartifact:DescribeRepository"
-                - "codeartifact:ListRepositories"
-                - "codeartifact:AssociateExternalConnection"
                 - "codeartifact:DisassociateExternalConnection"
+                - "codeartifact:ListRepositories"
                 - "codeartifact:PutRepositoryPermissionPolicy"
                 - "codeartifact:PutRepositoryPermissionsPolicy"
                 - "codeartifact:UpdateRepository"

--- a/aws-codeartifact-repository/resource-role.yaml
+++ b/aws-codeartifact-repository/resource-role.yaml
@@ -30,7 +30,6 @@ Resources:
                 - "codeartifact:DescribeRepository"
                 - "codeartifact:DisassociateExternalConnection"
                 - "codeartifact:ListRepositories"
-                - "codeartifact:PutRepositoryPermissionPolicy"
                 - "codeartifact:PutRepositoryPermissionsPolicy"
                 - "codeartifact:UpdateRepository"
                 Resource: "*"

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
@@ -1,8 +1,22 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.amazonaws.util.CollectionUtils;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionResponse;
+import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
+import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -30,4 +44,83 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     final CallbackContext callbackContext,
     final ProxyClient<CodeartifactClient> proxyClient,
     final Logger logger);
+
+  protected ProgressEvent<ResourceModel, CallbackContext> associateExternalConnections(
+      final ProgressEvent<ResourceModel, CallbackContext> progress,
+      final CallbackContext callbackContext,
+      final ResourceHandlerRequest<ResourceModel> request,
+      final ProxyClient<CodeartifactClient> proxyClient,
+      final Set<String> externalConnectionsToAdd,
+      final Logger logger
+  ) {
+      ResourceModel resourceModel = request.getDesiredResourceState();
+
+      if (CollectionUtils.isNullOrEmpty(externalConnectionsToAdd)) {
+          // Nothing to add, continue
+          return ProgressEvent.progress(resourceModel, callbackContext);
+      }
+
+      if (externalConnectionsToAdd.size() > 1) {
+          return ProgressEvent.failed(resourceModel, callbackContext, HandlerErrorCode.InvalidRequest,
+              "ExternalConnections for repositories are currently limited to 1.");
+      }
+
+      // Loop is currently not necessary because only 1 external connection is allowed, leaving this in for
+      // when multiple are supported
+      externalConnectionsToAdd.forEach(ec -> {
+          try {
+              AssociateExternalConnectionRequest associateExternalConnectionRequest
+                  = Translator.translateAssociateExternalConnectionsRequest(resourceModel, ec);
+
+              proxyClient.injectCredentialsAndInvokeV2(associateExternalConnectionRequest, proxyClient.client()::associateExternalConnection);
+          } catch (final AwsServiceException e) {
+              String repositoryName = progress.getResourceModel().getRepositoryName();
+              Translator.throwCfnException(e, Constants.ASSOCIATE_EXTERNAL_CONNECTION, repositoryName);
+          }
+          logger.log(String.format("Successfully associated external connection: %s", ec));
+      });
+
+      return ProgressEvent.<ResourceModel, CallbackContext>builder()
+          .resourceModel(resourceModel)
+          .status(OperationStatus.IN_PROGRESS)
+          .build();
+  }
+
+  protected ProgressEvent<ResourceModel, CallbackContext> putRepositoryPermissionsPolicy(
+      final AmazonWebServicesClientProxy proxy,
+      final ProgressEvent<ResourceModel, CallbackContext> progress,
+      final CallbackContext callbackContext,
+      final ProxyClient<CodeartifactClient> proxyClient,
+      final Logger logger
+  ) {
+      final ResourceModel desiredModel = progress.getResourceModel();
+      if (desiredModel.getPolicyDocument() == null) {
+          return ProgressEvent.progress(desiredModel, callbackContext);
+      }
+      return proxy.initiate("AWS-CodeArtifact-Repository::Update::PutRepositoryPermissionsPolicy", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+          .translateToServiceRequest(Translator::translatePutPermissionsPolicyRequest)
+          .makeServiceCall((awsRequest, client) -> {
+              PutRepositoryPermissionsPolicyResponse awsResponse = null;
+              try {
+                  awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, client.client()::putRepositoryPermissionsPolicy);
+                  logger.log("Repository permission policy successfully added.");
+              } catch (final AwsServiceException e) {
+                  String domainName = desiredModel.getDomainName();
+                  Translator.throwCfnException(e, Constants.PUT_REPOSITORY_POLICY, domainName);
+              }
+              return awsResponse;
+          })
+          .stabilize((awsRequest, awsResponse, client, model, context) -> policyIsStabilized(model, client))
+          .progress();
+  }
+
+  private boolean policyIsStabilized(final ResourceModel model, final ProxyClient<CodeartifactClient> proxyClient) {
+      try {
+          proxyClient.injectCredentialsAndInvokeV2(Translator.translateToGetRepositoryPermissionsPolicy(model), proxyClient.client()::getRepositoryPermissionsPolicy);
+          return true;
+      } catch (ResourceNotFoundException e) {
+          return false;
+      }
+  }
+
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
@@ -54,8 +54,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       final Logger logger
   ) {
       ResourceModel resourceModel = request.getDesiredResourceState();
-
+      logger.log(String.format("Adding external connections: %s", externalConnectionsToAdd.toString()));
       if (CollectionUtils.isNullOrEmpty(externalConnectionsToAdd)) {
+          logger.log("No external connections to add");
           // Nothing to add, continue
           return ProgressEvent.progress(resourceModel, callbackContext);
       }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
@@ -1,11 +1,13 @@
 package software.amazon.codeartifact.repository;
 
 public class Constants {
-    public static final String CREATE_REPOSITORY = "codeartifact::CreateRepository";
-    public static final String DESCRIBE_REPOSITORY = "codeartifact::DescribeRepository";
-    public static final String DELETE_REPOSITORY = "codeartifact::DeleteRepository";
-    public static final String PUT_REPOSITORY_POLICY = "codeartifact::PutRepositoryPermissionPolicy";
-    public static final String ASSOCIATE_EXTERNAL_CONNECTION = "codeartifact::AssociateExternalConnection";
-    public static final String DISASSOCIATE_EXTERNAL_CONNECTION = "codeartifact::DisassociateExternalConnection";
+    public static final String CREATE_REPOSITORY = "codeartifact:CreateRepository";
+    public static final String UPDATE_REPOSITORY = "codeartifact:UpdateRepository";
+    public static final String DESCRIBE_REPOSITORY = "codeartifact:DescribeRepository";
+    public static final String DELETE_REPOSITORY = "codeartifact:DeleteRepository";
+    public static final String PUT_REPOSITORY_POLICY = "codeartifact:PutRepositoryPermissionsPolicy";
+    public static final String DELETE_REPOSITORY_POLICY = "codeartifact:DeleteRepositoryPermissionsPolicy";
+    public static final String ASSOCIATE_EXTERNAL_CONNECTION = "codeartifact:AssociateExternalConnection";
+    public static final String DISASSOCIATE_EXTERNAL_CONNECTION = "codeartifact:DisassociateExternalConnection";
 
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
@@ -4,4 +4,8 @@ public class Constants {
     public static final String CREATE_REPOSITORY = "codeartifact::CreateRepository";
     public static final String DESCRIBE_REPOSITORY = "codeartifact::DescribeRepository";
     public static final String DELETE_REPOSITORY = "codeartifact::DeleteRepository";
+    public static final String PUT_REPOSITORY_POLICY = "codeartifact::PutRepositoryPermissionPolicy";
+    public static final String ASSOCIATE_EXTERNAL_CONNECTION = "codeartifact::AssociateExternalConnection";
+    public static final String DISASSOCIATE_EXTERNAL_CONNECTION = "codeartifact::DisassociateExternalConnection";
+
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
@@ -1,9 +1,9 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Set;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
-import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -24,36 +24,36 @@ public class CreateHandler extends BaseHandlerStd {
         final Logger logger) {
 
         this.logger = logger;
+        ResourceModel model = request.getDesiredResourceState();
+        final Set<String> externalConnectionsToAdd = Translator.translateExternalConnectionFromDesiredResource(model);
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-            // STEP 1 [create/stabilize progress chain - required for resource creation]
-            .then(progress ->
-                proxy.initiate("AWS-CodeArtifact-Domain::Create", proxyClient,progress.getResourceModel(), progress.getCallbackContext())
-                    .translateToServiceRequest(Translator::translateToCreateRequest)
-                    .makeServiceCall((awsRequest, client) -> createRepository(progress, client, awsRequest))
-                    .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client))
-                    .progress()
-            )
-            // STEP 2 [describe call/chain to return the resource model]
+            .then(progress -> createRepository(proxy, progress, proxyClient))
+            .then(progress -> putRepositoryPermissionsPolicy(proxy, progress, callbackContext, proxyClient, logger))
+            .then(progress -> associateExternalConnections(progress, callbackContext, request, proxyClient, externalConnectionsToAdd, logger))
             .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 
-    private AwsResponse createRepository(
-        ProgressEvent<ResourceModel, CallbackContext>  progress,
-        ProxyClient<CodeartifactClient> client,
-        CreateRepositoryRequest awsRequest
+    private ProgressEvent<ResourceModel, CallbackContext> createRepository(
+        AmazonWebServicesClientProxy proxy,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
+        ProxyClient<CodeartifactClient> proxyClient
     ) {
-        AwsResponse awsResponse = null;
-        try {
-            awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, client.client()::createRepository);
-        } catch (final AwsServiceException e) {
-            String repositoryName = progress.getResourceModel().getRepositoryName();
-            Translator.throwCfnException(e, Constants.CREATE_REPOSITORY, repositoryName);
-        }
-
-        // TODO Add Policy, Upstream, ExternalConnections if provided
-        logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
-        return awsResponse;
+        return proxy.initiate("AWS-CodeArtifact-Repository::Create", proxyClient,progress.getResourceModel(), progress.getCallbackContext())
+            .translateToServiceRequest(Translator::translateToCreateRequest)
+            .makeServiceCall((awsRequest, client) -> {
+                AwsResponse awsResponse = null;
+                try {
+                    awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, client.client()::createRepository);
+                } catch (final AwsServiceException e) {
+                    String repositoryName = progress.getResourceModel().getRepositoryName();
+                    Translator.throwCfnException(e, Constants.CREATE_REPOSITORY, repositoryName);
+                }
+                logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
+                return awsResponse;
+            })
+            .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client))
+            .progress();
     }
 
     private boolean isStabilized(

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
@@ -29,7 +29,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
             .then(progress -> createRepository(proxy, progress, proxyClient))
-            .then(progress -> putRepositoryPermissionsPolicy(proxy, progress, callbackContext, proxyClient, logger))
+            .then(progress -> putRepositoryPermissionsPolicy(proxy, progress, callbackContext, request, proxyClient, logger))
             .then(progress -> associateExternalConnections(progress, callbackContext, request, proxyClient, externalConnectionsToAdd, logger))
             .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -1,6 +1,8 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -74,7 +76,7 @@ public class Translator {
    */
   static List<UpstreamRepository> translateToUpstreamList(final ResourceModel model) {
     if (model.getUpstreams() == null) {
-      return null;
+      return Collections.emptyList();
     }
 
     return model.getUpstreams()
@@ -146,7 +148,7 @@ public class Translator {
           .domain(resourceModel.getDomainName())
           .repository(resourceModel.getRepositoryName())
           .domainOwner(resourceModel.getDomainOwner())
-          .policyDocument(MAPPER.writeValueAsString(resourceModel.getPolicyDocument()))
+          .policyDocument(MAPPER.writeValueAsString(resourceModel.getPermissionsPolicyDocument()))
           .build();
     } catch (final JsonProcessingException e) {
         throw new CfnInvalidRequestException(e);

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -3,24 +3,35 @@ package software.amazon.codeartifact.repository;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.model.AccessDeniedException;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionRequest;
 import software.amazon.awssdk.services.codeartifact.model.ConflictException;
 import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryRequest;
+import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.DisassociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
+import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
+import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryRequest;
+import software.amazon.awssdk.services.codeartifact.model.UpstreamRepository;
+import software.amazon.awssdk.services.codeartifact.model.UpstreamRepositoryInfo;
 import software.amazon.awssdk.services.codeartifact.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
@@ -38,6 +49,7 @@ import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededExceptio
  */
 
 public class Translator {
+  public static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Request to create a resource
@@ -48,9 +60,37 @@ public class Translator {
     return CreateRepositoryRequest.builder()
         .domain(model.getDomainName())
         .domainOwner(model.getDomainOwner())
+        .upstreams(translateToUpstreamList(model))
         .repository(model.getRepositoryName())
         .description(model.getDescription())
         .build();
+  }
+
+  /**
+   * Translates ResourceModel upstream array into UpstreamRepository List
+   * @param model resource model
+   * @return list of UpstreamRepository
+   */
+  static List<UpstreamRepository> translateToUpstreamList(final ResourceModel model) {
+    return streamOfOrEmpty(model.getUpstreams())
+        .map(upstream -> UpstreamRepository.builder()
+            .repositoryName(upstream)
+            .build()
+        )
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Translates repositoryDescription to list of strings
+   * @param repositoryDescription repo description
+   * @return list of repository names
+   */
+  static List<String> translateToUpstreamsFromRepoDescription(
+      final RepositoryDescription repositoryDescription
+  ) {
+    return streamOfOrEmpty(repositoryDescription.upstreams())
+        .map(UpstreamRepositoryInfo::repositoryName)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -74,14 +114,63 @@ public class Translator {
   static ResourceModel translateFromReadResponse(final DescribeRepositoryResponse describeRepositoryResponse) {
     RepositoryDescription repositoryDescription = describeRepositoryResponse.repository();
     return ResourceModel.builder()
-        // TODO add external connections and upstreams to read response
+        // TODO add external connections and policy document
+        // https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-codeartifact/issues/18
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
         .administratorAccount(repositoryDescription.administratorAccount())
         .domainName(repositoryDescription.domainName())
+        .upstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()))
         .domainOwner(repositoryDescription.domainOwner())
         .description(repositoryDescription.description())
         .repositoryName(repositoryDescription.name())
+        .build();
+  }
+
+  /**
+   * Translates resource model into PutRepositoryPermissionsPolicyRequest
+   * @param resourceModel resource model
+   * @return PutRepositoryPermissionsPolicyRequest
+   */
+  public static PutRepositoryPermissionsPolicyRequest translatePutPermissionsPolicyRequest(
+      ResourceModel resourceModel
+  ) {
+    try {
+      return PutRepositoryPermissionsPolicyRequest.builder()
+          .domain(resourceModel.getDomainName())
+          .repository(resourceModel.getRepositoryName())
+          .domainOwner(resourceModel.getDomainOwner())
+          .policyDocument(MAPPER.writeValueAsString(resourceModel.getPolicyDocument()))
+          .build();
+    } catch (final JsonProcessingException e) {
+        throw new CfnInvalidRequestException(e);
+      }
+  }
+
+  /**
+   * Translates resource model into DeleteRepositoryPermissionsPolicyRequest
+   * @param resourceModel resource model
+   * @return DeleteRepositoryPermissionsPolicyRequest
+   */
+  public static DeleteRepositoryPermissionsPolicyRequest translateDeletePermissionsPolicyRequest(
+      ResourceModel resourceModel
+  ) {
+      return DeleteRepositoryPermissionsPolicyRequest.builder()
+          .domain(resourceModel.getDomainName())
+          .domainOwner(resourceModel.getDomainOwner())
+          .repository(resourceModel.getRepositoryName())
+          .build();
+  }
+
+  /**
+   * Request to describe repository permissions policy
+   * @param model resource model
+   * @return awsRequest the aws service request to describe a policy
+   */
+  static GetRepositoryPermissionsPolicyRequest translateToGetRepositoryPermissionsPolicy(final ResourceModel model) {
+    return GetRepositoryPermissionsPolicyRequest.builder()
+        .domain(model.getDomainName())
+        .domainOwner(model.getDomainOwner())
         .build();
   }
 
@@ -91,7 +180,7 @@ public class Translator {
    * @return awsRequest the aws service request to delete a resource
    */
   static DeleteRepositoryRequest translateToDeleteRequest(final ResourceModel model) {
-    return  DeleteRepositoryRequest.builder()
+    return DeleteRepositoryRequest.builder()
         .domain(model.getDomainName())
         .domainOwner(model.getDomainOwner())
         .repository(model.getRepositoryName())
@@ -99,26 +188,57 @@ public class Translator {
   }
 
   /**
-   * Request to update properties of a previously created resource
+   * Request to associate External Connection
    * @param model resource model
+   * @param  externalConnectionToAdd external connection to associate
    * @return awsRequest the aws service request to modify a resource
    */
-  static AwsRequest translateToFirstUpdateRequest(final ResourceModel model) {
-    final AwsRequest awsRequest = null;
-    // TODO: construct a request
-    // e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/blob/2077c92299aeb9a68ae8f4418b5e932b12a8b186/aws-logs-loggroup/src/main/java/com/aws/logs/loggroup/Translator.java#L45-L50
-    return awsRequest;
+  static AssociateExternalConnectionRequest translateAssociateExternalConnectionsRequest(
+      final ResourceModel model,
+      final String externalConnectionToAdd
+  ) {
+    return AssociateExternalConnectionRequest.builder()
+        .domain(model.getDomainName())
+        .repository(model.getRepositoryName())
+        .domainOwner(model.getDomainOwner())
+        .externalConnection(externalConnectionToAdd)
+        .build();
+  }
+
+  static Set<String> translateExternalConnectionFromDesiredResource(final ResourceModel model) {
+    return streamOfOrEmpty(model.getExternalConnections())
+        .collect(Collectors.toSet());
   }
 
   /**
-   * Request to update some other properties that could not be provisioned through first update request
+   * Request to remove External Connection from Repository
+   * @param model resource model
+   * @param externalConnectionToRemove External Connections to remove
+   * @return awsRequest the aws service request to modify a resource
+   */
+  static DisassociateExternalConnectionRequest translateDisassociateExternalConnectionsRequest(
+      final ResourceModel model,
+      final String externalConnectionToRemove
+  ) {
+    return DisassociateExternalConnectionRequest.builder()
+        .domain(model.getDomainName())
+        .domainOwner(model.getDomainOwner())
+        .externalConnection(externalConnectionToRemove)
+        .build();
+  }
+
+  /**
+   * Request to update Repository
    * @param model resource model
    * @return awsRequest the aws service request to modify a resource
    */
-  static AwsRequest translateToSecondUpdateRequest(final ResourceModel model) {
-    final AwsRequest awsRequest = null;
-    // TODO: construct a request
-    return awsRequest;
+  static UpdateRepositoryRequest translateToUpdateRepository(final ResourceModel model) {
+    return UpdateRepositoryRequest.builder()
+        .domain(model.getDomainName())
+        .domainOwner(model.getDomainOwner())
+        .description(model.getDescription())
+        .upstreams(translateToUpstreamList(model))
+        .build();
   }
 
   /**
@@ -148,7 +268,7 @@ public class Translator {
         .collect(Collectors.toList());
   }
 
-  private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+  public static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
     return Optional.ofNullable(collection)
         .map(Collection::stream)
         .orElseGet(Stream::empty);

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -1,6 +1,8 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -14,8 +16,12 @@ import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import org.apache.commons.collections.map.HashedMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractTestBase {
   protected static final String DOMAIN_NAME = "test-domain-name";
@@ -26,6 +32,12 @@ public class AbstractTestBase {
   protected static final Map<String, Object> TEST_POLICY_DOC = Collections.singletonMap("key", "value");
   protected static final String TEST_POLICY_DOC_JSON = "{\"key\":\"value\"}";
   protected static final String DESCRIPTION = "repoDescription";
+  protected final String UPSTREAM_0 = "upstream0";
+  protected final String UPSTREAM_1 = "upstream1";
+  protected final String NPM_EC = "public:npmjs";
+  protected final String PYPI_EC = "public:pypi";
+
+  protected final List<String> UPSTREAMS = Arrays.asList(UPSTREAM_0,UPSTREAM_1);
 
   protected static final Credentials MOCK_CREDENTIALS;
   protected static final LoggerProxy logger;
@@ -75,5 +87,18 @@ public class AbstractTestBase {
         return sdkClient;
       }
     };
+  }
+
+  protected void assertSuccess(
+      ProgressEvent<ResourceModel, CallbackContext> response,
+      ResourceModel desiredOutputModel
+  ) {
+    assertThat(response).isNotNull();
+    assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+    assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+    assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
+    assertThat(response.getResourceModels()).isNull();
+    assertThat(response.getMessage()).isNull();
+    assertThat(response.getErrorCode()).isNull();
   }
 }

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -21,15 +21,20 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import org.apache.commons.collections.map.HashedMap;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractTestBase {
+  public static final ObjectMapper MAPPER = new ObjectMapper();
   protected static final String DOMAIN_NAME = "test-domain-name";
   protected static final String DOMAIN_OWNER = "12345";
   protected static final String ADMIN_ACCOUNT = "54321";
   protected static final String REPO_ARN = "repoArn";
   protected static final String REPO_NAME = "test-repo-name";
-  protected static final Map<String, Object> TEST_POLICY_DOC = Collections.singletonMap("key", "value");
+  protected static final Map<String, Object> TEST_POLICY_DOC_0 = Collections.singletonMap("key0", "value0");
+  protected static final Map<String, Object> TEST_POLICY_DOC_1 = Collections.singletonMap("key1", "value1");
+
   protected static final String TEST_POLICY_DOC_JSON = "{\"key\":\"value\"}";
   protected static final String DESCRIPTION = "repoDescription";
   protected final String UPSTREAM_0 = "upstream0";

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -1,5 +1,7 @@
 package software.amazon.codeartifact.repository;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.awscore.AwsRequest;
@@ -13,6 +15,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
+import org.apache.commons.collections.map.HashedMap;
 
 public class AbstractTestBase {
   protected static final String DOMAIN_NAME = "test-domain-name";
@@ -20,6 +23,8 @@ public class AbstractTestBase {
   protected static final String ADMIN_ACCOUNT = "54321";
   protected static final String REPO_ARN = "repoArn";
   protected static final String REPO_NAME = "test-repo-name";
+  protected static final Map<String, Object> TEST_POLICY_DOC = Collections.singletonMap("key", "value");
+  protected static final String TEST_POLICY_DOC_JSON = "{\"key\":\"value\"}";
   protected static final String DESCRIPTION = "repoDescription";
 
   protected static final Credentials MOCK_CREDENTIALS;

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -63,9 +63,6 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Mock
     CodeartifactClient codeartifactClient;
 
-    private final String UPSTREAM_0 = "upstream0";
-    private final String UPSTREAM_1 = "upstream1";
-
     @BeforeEach
     public void setup() {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
@@ -127,13 +124,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertSuccess(response, desiredOutputModel);
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
@@ -143,13 +134,11 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void handleRequest_withUpstreams() {
         final CreateHandler handler = new CreateHandler();
 
-        List<String> upstreams = Arrays.asList(UPSTREAM_0, UPSTREAM_1);
-
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .upstreams(upstreams)
+            .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
             .build();
 
@@ -158,7 +147,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(upstreams)
+            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -169,10 +158,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
-            .upstreams(
-                UpstreamRepositoryInfo.builder().repositoryName("upstream0").build(),
-                UpstreamRepositoryInfo.builder().repositoryName("upstream1").build()
-            )
             .domainName(DOMAIN_NAME)
             .build();
 
@@ -194,13 +179,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertSuccess(response, desiredOutputModel);
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
@@ -256,13 +235,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertSuccess(response, desiredOutputModel);
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
@@ -289,7 +262,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .externalConnections(Collections.singletonList("public:npmjs"))
+            .externalConnections(Collections.singletonList(NPM_EC))
             .description(DESCRIPTION)
             .build();
 
@@ -330,17 +303,10 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        assertSuccess(response, desiredOutputModel);
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
-
         verify(codeartifactClient).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
     }
 
@@ -388,7 +354,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(1)).describeRepository(any(DescribeRepositoryRequest.class));
-
         verify(codeartifactClient, never()).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
     }
 

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.codeartifact.repository;
 
 import java.time.Duration;
+import java.util.Collections;
 import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.ConflictException;
@@ -75,6 +76,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         .domainName(DOMAIN_NAME)
         .domainOwner(DOMAIN_OWNER)
         .arn(REPO_ARN)
+        .upstreams(Collections.emptyList())
         .repositoryName(REPO_NAME)
         .description(DESCRIPTION)
         .administratorAccount(ADMIN_ACCOUNT)

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
@@ -1,25 +1,44 @@
 package software.amazon.codeartifact.repository;
 
-import java.time.Duration;
-import software.amazon.awssdk.core.SdkClient;
-import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
+import software.amazon.awssdk.services.codeartifact.model.AssociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermissionsPolicyRequest;
+import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
+import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.DisassociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyRequest;
+import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyRequest;
+import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
+import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.codeartifact.model.ResourcePolicy;
+import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryRequest;
+import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.UpstreamRepositoryInfo;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
@@ -31,28 +50,380 @@ public class UpdateHandlerTest extends AbstractTestBase {
     private ProxyClient<CodeartifactClient> proxyClient;
 
     @Mock
-    CodeartifactClient sdkClient;
+    CodeartifactClient codeartifactClient;
+
+    final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+        .name(REPO_NAME)
+        .administratorAccount(ADMIN_ACCOUNT)
+        .arn(REPO_ARN)
+        .description(DESCRIPTION)
+        .domainOwner(DOMAIN_OWNER)
+        .domainName(DOMAIN_NAME)
+        .build();
 
     @BeforeEach
     public void setup() {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
-        sdkClient = mock(CodeartifactClient.class);
-        proxyClient = MOCK_PROXY(proxy, sdkClient);
+        codeartifactClient = mock(CodeartifactClient.class);
+        proxyClient = MOCK_PROXY(proxy, codeartifactClient);
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void handleRequest_SimpleSuccess_withPolicyDoc() {
         final UpdateHandler handler = new UpdateHandler();
 
-        final ResourceModel model = ResourceModel.builder().build();
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .policyDocument(TEST_POLICY_DOC)
+            .build();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN)
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .build();
+
+        PutRepositoryPermissionsPolicyResponse putRepoPolicyResponse = PutRepositoryPermissionsPolicyResponse.builder()
+            .policy(
+                ResourcePolicy.builder()
+                    .document(TEST_POLICY_DOC_JSON)
+                    .build()
+            )
+            .build();
+
+        when(proxyClient.client().putRepositoryPermissionsPolicy(any(PutRepositoryPermissionsPolicyRequest.class))).thenReturn(putRepoPolicyResponse);
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
             .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler
-            .handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
-        // TODO Add tests after implementation
+        assertSuccess(response, desiredOutputModel);
+
+        verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class));
+        verify(codeartifactClient).putRepositoryPermissionsPolicy(any(PutRepositoryPermissionsPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_withUpstreams() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .upstreams(UPSTREAMS)
+            .policyDocument(TEST_POLICY_DOC)
+            .build();
+
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .upstreams(
+                UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_0).build(),
+                UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_1).build()
+            )
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN)
+            .upstreams(UPSTREAMS)
+            .description(DESCRIPTION)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .build();
+
+        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertSuccess(response, desiredOutputModel);
+
+        verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).updateRepository(any(UpdateRepositoryRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_withNewExternalConnections() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
+            .description(DESCRIPTION)
+            .build();
+
+        // describe repo response has no external connections, we need to add the one in the Resourcemodel
+        final RepositoryDescription repositoryDescription = RepoInfoWithOutExternalConnections();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN)
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .build();
+
+        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+        when(proxyClient.client().deleteRepositoryPermissionsPolicy(any(DeleteRepositoryPermissionsPolicyRequest.class)))
+            .thenReturn(DeleteRepositoryPermissionsPolicyResponse.builder().build());
+
+        // this happens when permission policy is stabilized
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(
+            ResourceNotFoundException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertSuccess(response, desiredOutputModel);
+        verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).updateRepository(any(UpdateRepositoryRequest.class));
+
+        verify(codeartifactClient).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_withSameExternalConnections() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
+            .description(DESCRIPTION)
+            .build();
+
+        // describe repo response has no external connections, we need to add the one in the Resourcemodel
+        final RepositoryDescription repositoryDescription = RepoInfoWithNpmExternalConnection();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN)
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .build();
+
+        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+        when(proxyClient.client().deleteRepositoryPermissionsPolicy(any(DeleteRepositoryPermissionsPolicyRequest.class)))
+            .thenReturn(DeleteRepositoryPermissionsPolicyResponse.builder().build());
+        // this happens when permission policy is stabilized
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(
+            ResourceNotFoundException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertSuccess(response, desiredOutputModel);
+        verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).updateRepository(any(UpdateRepositoryRequest.class));
+
+        verify(codeartifactClient, never()).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_withExistingExternalConnections() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
+            .description(DESCRIPTION)
+            .build();
+
+        // describe repo response has one external connection, we need to remove and add new one
+        final RepositoryDescription repositoryDescription = RepoInfoWithPypIExternalConnection();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN)
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .build();
+
+        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+        when(proxyClient.client().deleteRepositoryPermissionsPolicy(any(DeleteRepositoryPermissionsPolicyRequest.class)))
+            .thenReturn(DeleteRepositoryPermissionsPolicyResponse.builder().build());
+        // this happens when permission policy is stabilized
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(
+            ResourceNotFoundException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertSuccess(response, desiredOutputModel);
+        verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).updateRepository(any(UpdateRepositoryRequest.class));
+        verify(codeartifactClient).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+        verify(codeartifactClient).disassociateExternalConnection(any(DisassociateExternalConnectionRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_withTooManyExternalConnections() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .externalConnections(Arrays.asList(NPM_EC, PYPI_EC))
+            .description(DESCRIPTION)
+            .build();
+
+        // describe repo response has no external connections, we need to add the one in the ResourceModel
+        final RepositoryDescription repositoryDescription = RepoInfoWithOutExternalConnections();
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+        when(proxyClient.client().deleteRepositoryPermissionsPolicy(any(DeleteRepositoryPermissionsPolicyRequest.class)))
+            .thenReturn(DeleteRepositoryPermissionsPolicyResponse.builder().build());
+
+        // this happens when permission policy is stabilized
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(
+            ResourceNotFoundException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+
+        verify(codeartifactClient).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, never()).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+        verify(codeartifactClient, never()).disassociateExternalConnection(any(DisassociateExternalConnectionRequest.class));
+    }
+
+    RepositoryDescription RepoInfoWithOutExternalConnections() {
+        return RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+    }
+
+    RepositoryDescription RepoInfoWithPypIExternalConnection() {
+        return RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .externalConnections(
+                RepositoryExternalConnectionInfo.builder()
+                .externalConnectionName(PYPI_EC)
+                .build()
+            )
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+    }
+
+    RepositoryDescription RepoInfoWithNpmExternalConnection() {
+        return RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .externalConnections(
+                RepositoryExternalConnectionInfo.builder()
+                    .externalConnectionName(NPM_EC)
+                    .build()
+            )
+            .upstreams(Collections.emptyList())
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow for upstreams, external connections, and policies to be specified on Create and Update

*Testing*
Using `cfn invoke CREATE` to create a repository with external connections and validated. 
Using `cfn invoke CREATE` to create a repository with upstreams and validated. 

Using `cfn invoke UPDATE` to update ExternalConnections on a repository without one
Using `cfn invoke UPDATE` to update RepoPolicy on a repository
Using `cfn invoke UPDATE` to update ExternalConnections on a repository with one, to overwrite 
Using `cfn invoke UPDATE` to update ExternalConnections and remove the EC that was on the repo
Using `cfn invoke UPDATE` to update ExternalConnections with more than 1 EC to see if the update would fail

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
