### PR TITLE
Fixing some of the contract tests for Domain.

### DIFF
--- a/aws-codeartifact-domain/aws-codeartifact-domain.json
+++ b/aws-codeartifact-domain/aws-codeartifact-domain.json
@@ -6,7 +6,7 @@
     "DomainName": {
       "description": "The name of the domain.",
       "type": "string",
-      "pattern": "[a-z][a-z0-9\\-]{0,48}[a-z0-9]",
+      "pattern": "^([a-z][a-z0-9\\-]{0,48}[a-z0-9])$",
       "minLength": 2,
       "maxLength": 50
     },
@@ -39,12 +39,9 @@
       ],
       "type": "string"
     },
-    "PolicyDocument": {
+    "PermissionsPolicyDocument": {
       "description": "The access control resource policy on the provided domain.",
-      "type": [
-        "object",
-        "string"
-      ],
+      "type": "object",
       "minLength": 2,
       "maxLength": 5120
     },
@@ -56,6 +53,9 @@
     }
   },
   "additionalProperties": false,
+  "required": [
+    "DomainName"
+  ],
   "createOnlyProperties": [
     "/properties/DomainName",
     "/properties/EncryptionKey"
@@ -64,7 +64,8 @@
     "/properties/Arn",
     "/properties/CreatedTime",
     "/properties/RepositoryCount",
-    "/properties/AssetSizeBytes"
+    "/properties/AssetSizeBytes",
+    "/properties/DomainOwner"
   ],
   "primaryIdentifier": [
     "/properties/Arn"

--- a/aws-codeartifact-domain/overrides.json
+++ b/aws-codeartifact-domain/overrides.json
@@ -1,0 +1,17 @@
+{
+  "CREATE": {
+    "/PermissionsPolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "codeartifact:*",
+          "Resource": "*"
+        }
+      ]
+    },
+    "/EncryptionKey": null,
+    "/DomainOwner": null
+  }
+}

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/BaseHandlerStd.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/BaseHandlerStd.java
@@ -14,7 +14,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
-  public static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   @Override
   public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
     final AmazonWebServicesClientProxy proxy,

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Constants.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Constants.java
@@ -2,12 +2,12 @@ package software.amazon.codeartifact.domain;
 
 public class Constants {
 
-    public static final String CREATE_DOMAIN = "codeartifact::CreateDomain";
-    public static final String LIST_DOMAINS = "codeartifact::ListDomains";
-    public static final String PUT_DOMAIN_POLICY = "codeartifact::PutDomainPermissionsPolicy";
-    public static final String DELETE_DOMAIN_PERMISSION_POLICY = "codeartifact::DeleteDomainPermissionsPolicy";
-    public static final String DELETE_DOMAIN = "codeartifact::DeleteDomain";
-    public static final String DESCRIBE_DOMAIN = "codeartifact::DescribeDomain";
+    public static final String CREATE_DOMAIN = "codeartifact:CreateDomain";
+    public static final String LIST_DOMAINS = "codeartifact:ListDomains";
+    public static final String PUT_DOMAIN_POLICY = "codeartifact:PutDomainPermissionsPolicy";
+    public static final String DELETE_DOMAIN_PERMISSION_POLICY = "codeartifact:DeleteDomainPermissionsPolicy";
+    public static final String DELETE_DOMAIN = "codeartifact:DeleteDomain";
+    public static final String DESCRIBE_DOMAIN = "codeartifact:DescribeDomain";
     public static final String ACTIVE_STATUS = "Active";
     public static final int MAX_ITEMS = 1000;
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/DeleteHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/DeleteHandler.java
@@ -2,11 +2,10 @@ package software.amazon.codeartifact.domain;
 
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
-import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
-import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.awssdk.services.codeartifact.model.ConflictException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -24,44 +23,43 @@ public class DeleteHandler extends BaseHandlerStd {
         final Logger logger) {
 
         this.logger = logger;
+        ResourceModel model = request.getDesiredResourceState();
+        // STEP 1.0 [initialize a proxy context]
+        ProgressEvent<ResourceModel, CallbackContext> test = proxy
+            .initiate("AWS-CodeArtifact-Domain::Delete", proxyClient, model, callbackContext)
+            // STEP 1.1 [construct a body of a request]
+            .translateToServiceRequest(Translator::translateToDeleteRequest)
+            // STEP 1.2 [make an api call]
+            .makeServiceCall((awsRequest, client) -> {
 
-        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+                // if domain does not exist, deleteDomain does not throw an exception, so we must do this
+                // to be under the ResourceHandler Contract
+                if (!doesDomainExist(model, proxyClient, request)) {
+                    throw new CfnNotFoundException(model.getDomainName(), ResourceModel.TYPE_NAME);
+                }
 
-            // STEP 1.0 [delete/stabilize progress chain - required for resource deletion]
-            .then(progress ->
-                // STEP 1.0 [initialize a proxy context]
-                proxy.initiate("AWS-CodeArtifact-Domain::Delete", proxyClient, progress.getResourceModel(),
-                    progress.getCallbackContext())
-                    // STEP 1.1 [construct a body of a request]
-                    .translateToServiceRequest(Translator::translateToDeleteRequest)
-                    // STEP 1.2 [make an api call]
-                    .makeServiceCall((awsRequest, client) -> {
-                        AwsResponse awsResponse = null;
-                        try {
-                            awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::deleteDomain);
-                        } catch (final AwsServiceException e) {
-                            String domainName = progress.getResourceModel().getDomainName();
-                            Translator.throwCfnException(e, Constants.DELETE_DOMAIN, domainName);
-                        }
+                AwsResponse awsResponse = null;
+                try {
+                    awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::deleteDomain);
+                } catch (final ConflictException e) {
+                    // this happens if the domain has repositories in the account
+                    throw new CfnResourceConflictException(ResourceModel.TYPE_NAME, model.getDomainName(), e.getMessage(), e);
+                } catch (final AwsServiceException e) {
+                    String domainName = model.getDomainName();
+                    Translator.throwCfnException(e, Constants.DELETE_DOMAIN, domainName);
+                }
 
-                        logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));
-                        return awsResponse;
-                    })
-                    // STEP 2.3 [Stabilize to check if the resource got deleted]
-                    .stabilize((deleteDomainRequest, deleteDomainResponse, proxyInvocation, model, context) -> isDeleted(model, proxyInvocation, request))
-                    .success());
+                logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));
+                return awsResponse;
+            })
+            // STEP 2.3 [Stabilize to check if the resource got deleted]
+            .stabilize((deleteDomainRequest, deleteDomainResponse, proxyInvocation, resourceModel, context) -> !doesDomainExist(model, proxyClient, request))
+            .success();
+
+
+        // according to the ResourceHandler contract we must not return the model in the response
+        test.setResourceModel(null);
+        return test;
     }
 
-    protected boolean isDeleted(final ResourceModel model,
-        final ProxyClient<CodeartifactClient> proxyClient,
-        ResourceHandlerRequest<ResourceModel> request
-    ) {
-        try {
-            proxyClient.injectCredentialsAndInvokeV2(
-                Translator.translateToReadRequest(model, request), proxyClient.client()::describeDomain);
-            return false;
-        } catch (ResourceNotFoundException e) {
-            return true;
-        }
-    }
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/DeleteHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/DeleteHandler.java
@@ -25,7 +25,7 @@ public class DeleteHandler extends BaseHandlerStd {
         this.logger = logger;
         ResourceModel model = request.getDesiredResourceState();
         // STEP 1.0 [initialize a proxy context]
-        ProgressEvent<ResourceModel, CallbackContext> test = proxy
+        ProgressEvent<ResourceModel, CallbackContext> deleteProgressEvent = proxy
             .initiate("AWS-CodeArtifact-Domain::Delete", proxyClient, model, callbackContext)
             // STEP 1.1 [construct a body of a request]
             .translateToServiceRequest(Translator::translateToDeleteRequest)
@@ -58,8 +58,8 @@ public class DeleteHandler extends BaseHandlerStd {
 
 
         // according to the ResourceHandler contract we must not return the model in the response
-        test.setResourceModel(null);
-        return test;
+        deleteProgressEvent.setResourceModel(null);
+        return deleteProgressEvent;
     }
 
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ListHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ListHandler.java
@@ -46,9 +46,10 @@ public class ListHandler extends BaseHandler<CallbackContext> {
         String nextToken = response.nextToken();
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModels(Translator.translateFromListRequest(response))
+            .resourceModels(Translator.translateFromListRequest(response, request))
             .nextToken(nextToken)
             .status(OperationStatus.SUCCESS)
             .build();
     }
+
 }

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/AbstractTestBase.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/AbstractTestBase.java
@@ -1,6 +1,8 @@
 package software.amazon.codeartifact.domain;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import software.amazon.awssdk.awscore.AwsRequest;
@@ -14,6 +16,8 @@ import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class AbstractTestBase {
   protected static final Credentials MOCK_CREDENTIALS;
   protected static final LoggerProxy logger;
@@ -22,12 +26,13 @@ public class AbstractTestBase {
   protected static final String DOMAIN_ARN = "testDomainArn";
   protected static final String ENCRYPTION_KEY_ARN = "testKeyArn";
   protected static final String DOMAIN_OWNER = "123456789";
-  protected static final String TEST_POLICY_DOC = "{\"Version\":\"2012-10-17\","
-      + "\"Statement\":[{\"Sid\":\"ContributorPolicy\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::946525001030:root\"},\"Action\":[\"codeartifact:CreateRepository\",\"codeartifact:DeleteDomain\",\"codeartifact:DeleteDomainPermissionsPolicy\",\"codeartifact:DescribeDomain\",\"codeartifact:GetAuthorizationToken\",\"codeartifact:GetDomainPermissionsPolicy\",\"codeartifact:ListRepositoriesInDomain\",\"codeartifact:PutDomainPermissionsPolicy\",\"sts:GetServiceBearerToken\"],\"Resource\":\"*\"}]}";
+  protected static final Map<String, Object> TEST_POLICY_DOC = Collections.singletonMap("key0", "value0");
   protected final Instant NOW = Instant.now();
   protected final int REPO_COUNT = 2;
   protected final String STATUS = "Active";
   protected final int ASSET_SIZE = 1234;
+
+  public static final ObjectMapper MAPPER = new ObjectMapper();
 
   static {
     MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
@@ -38,13 +38,14 @@ import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -98,7 +99,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .build();
 
         CreateDomainResponse createDomainResponse = CreateDomainResponse.builder()
@@ -134,13 +134,12 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_withDomainPolicy() {
+    public void handleRequest_withDomainPolicy() throws JsonProcessingException {
         final CreateHandler handler = new CreateHandler();
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
-            .policyDocument(TEST_POLICY_DOC)
+            .permissionsPolicyDocument(TEST_POLICY_DOC)
             .build();
 
         CreateDomainResponse createDomainResponse = CreateDomainResponse.builder()
@@ -182,10 +181,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         PutDomainPermissionsPolicyRequest capturedRequest = putDomainPermissionsPolicyRequestArgumentCaptor.getValue();
 
         assertThat(capturedRequest.domain()).isEqualTo(DOMAIN_NAME);
-        assertThat(capturedRequest.domainOwner()).isEqualTo(DOMAIN_OWNER);
-        assertThat(capturedRequest.policyDocument()).isEqualTo(TEST_POLICY_DOC);
-
-        verify(codeartifactClient).getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class));
+        assertThat(capturedRequest.policyDocument()).isEqualTo(MAPPER.writeValueAsString(TEST_POLICY_DOC));
     }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding in some fixes that make the handlers to adhere to https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html. 

`contract_invalid_create` still doesn't pass and I am going to reach out to CloudFormation to get guidance on this test

**NOTES**: 
+  I am manually adding in arns to the ListHandlers but we will not do this when `ListDomains` populates the arn in it's sdk response. The reason it's needed is because the primary identifier needs to be populated after a `list` operation
+ Also removing `domainOwner` from some of the operations because I am assuming that for for update/read permissions policies and describe domain, we are always doing so in the account the CFN stack is in.

*Testing*
```
handler_create.py::contract_create_delete PASSED                         [  6%]
handler_create.py::contract_invalid_create PASSED                        [ 12%]
handler_create.py::contract_create_duplicate SKIPPED                     [ 18%]
handler_create.py::contract_create_read_success PASSED                   [ 25%]
handler_create.py::contract_create_list_success PASSED                   [ 31%]
handler_delete.py::contract_delete_read PASSED                           [ 37%]
handler_delete.py::contract_delete_list PASSED                           [ 43%]
handler_delete.py::contract_delete_update PASSED                         [ 50%]
handler_delete.py::contract_delete_delete PASSED                         [ 56%]
handler_delete.py::contract_delete_create SKIPPED                        [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                      [ 68%]
handler_read.py::contract_read_without_create PASSED                     [ 75%]
handler_update.py::contract_update_read_success PASSED                   [ 81%]
handler_update.py::contract_update_list_success PASSED                   [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED   [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED  [100%]

```

When I run the tests that `ERROR` by themselves they pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
