### PR TITLE
Fixing bugs when External Connections and Upstreams.

### DIFF
--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ComparisonUtils.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ComparisonUtils.java
@@ -11,14 +11,6 @@ public class ComparisonUtils {
         return prevModel.getUpstreams() == null && desiredModel.getUpstreams() != null;
     }
 
-    public static boolean willNotUpdateUpstreams(final ResourceModel desiredModel, final ResourceModel prevModel) {
-        return upstreamsAreEqual(desiredModel, prevModel);
-    }
-
-    public static boolean willUpdateUpstreams(final ResourceModel desiredModel, final ResourceModel prevModel) {
-        return !upstreamsAreEqual(desiredModel, prevModel);
-    }
-
     public static boolean willNotUpdateDescription(final ResourceModel desiredModel, final ResourceModel prevModel) {
         return Objects.equals(prevModel.getDescription(), desiredModel.getDescription());
     }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ComparisonUtils.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ComparisonUtils.java
@@ -1,0 +1,35 @@
+package software.amazon.codeartifact.repository;
+
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+public class ComparisonUtils {
+
+    public static boolean willAddUpstreams(final ResourceModel desiredModel, final ResourceModel prevModel) {
+        return prevModel.getUpstreams() == null && desiredModel.getUpstreams() != null;
+    }
+
+    public static boolean willNotUpdateUpstreams(final ResourceModel desiredModel, final ResourceModel prevModel) {
+        return upstreamsAreEqual(desiredModel, prevModel);
+    }
+
+    public static boolean willUpdateUpstreams(final ResourceModel desiredModel, final ResourceModel prevModel) {
+        return !upstreamsAreEqual(desiredModel, prevModel);
+    }
+
+    public static boolean willNotUpdateDescription(final ResourceModel desiredModel, final ResourceModel prevModel) {
+        return Objects.equals(prevModel.getDescription(), desiredModel.getDescription());
+    }
+
+    public static boolean upstreamsAreEqual(final ResourceModel desiredModel, final ResourceModel prevModel) {
+        Set<String> prevUpstreamsSet = prevModel.getUpstreams() == null ? null :
+            Sets.newHashSet(prevModel.getUpstreams());
+
+        Set<String> desiredUpstreamsSet = desiredModel.getUpstreams() == null ? null :
+            Sets.newHashSet(desiredModel.getUpstreams());
+
+        return Objects.equals(prevUpstreamsSet, desiredUpstreamsSet);
+    }
+}

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -257,7 +257,7 @@ public class Translator {
         .repository(desiredModel.getRepositoryName())
         .description(desiredModel.getDescription());
 
-    if (ComparisonUtils.willUpdateUpstreams(desiredModel, prevModel)) {
+    if (!ComparisonUtils.upstreamsAreEqual(desiredModel, prevModel)) {
       // There is either upstreams to remove or upstreams to delete. This is here because adding an external connection
       // and trying to call .upstreams(emptyList) will cause a ValidationException with a repository with external
       // connections, so we skip the call if there is nothing to update.

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -257,7 +257,7 @@ public class Translator {
         .repository(desiredModel.getRepositoryName())
         .description(desiredModel.getDescription());
 
-    if (!Objects.equals(prevModel.getUpstreams(), desiredModel.getUpstreams())) {
+    if (ComparisonUtils.willUpdateUpstreams(desiredModel, prevModel)) {
       // There is either upstreams to remove or upstreams to delete. This is here because adding an external connection
       // and trying to call .upstreams(emptyList) will cause a ValidationException with a repository with external
       // connections, so we skip the call if there is nothing to update.

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/UpdateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/UpdateHandler.java
@@ -92,7 +92,7 @@ public class UpdateHandler extends BaseHandlerStd {
         Logger logger
     ) {
 
-        if (ComparisonUtils.willNotUpdateUpstreams(desiredModel, previousModel) &&
+        if (ComparisonUtils.upstreamsAreEqual(desiredModel, previousModel) &&
             ComparisonUtils.willNotUpdateDescription(desiredModel, previousModel)) {
             return ProgressEvent.progress(desiredModel, callbackContext);
         }


### PR DESCRIPTION
*Description of changes:* 
2 bugs to fix: 
+ External Connections could not be updated in the UpdateHandler because it was calling updateRepository with an empty list passed into `upstreams`, which attempted to remove upstreams with an external connection. This would through an exception. Fix: Only call updateHandler with the empty list upstream parameter if there is actually an upstream to remove, otherwise don't even try

+ External Connections could not be replaced with upstreams or vice versa. Fix: change ordering of operation depending on what we are trying to do

* Testing *

Ran `cfn submit --region us-west-2 --set-default`
+ create repo, added external connection (this was failing before due to a empty call to updateRepository) 
+ Created repo, added upstream, then updated with template with external connection
+ Created repo, added external connection, then updated with template with upstream
+ Created repo, added upstream, then removed upstream
+ Created repo, added external connection, then removed external connection


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
