### PR TITLE
Fixing contract tests for AWS::CodeArtifact::Repository

### DIFF
--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -6,14 +6,14 @@
     "RepositoryName": {
       "description": "The name of the repository.",
       "type": "string",
-      "pattern": "[A-Za-z0-9][A-Za-z0-9._\\-]{1,99}",
+      "pattern": "^([A-Za-z0-9][A-Za-z0-9._\\-]{1,99})$",
       "minLength": 2,
       "maxLength": 100
     },
     "DomainName": {
       "description": "The name of the domain that contains the repository.",
       "type": "string",
-      "pattern": "[a-z][a-z0-9\\-]{0,48}[a-z0-9]",
+      "pattern": "^([a-z][a-z0-9\\-]{0,48}[a-z0-9])$",
       "minLength": 2,
       "maxLength": 50
     },

--- a/aws-codeartifact-repository/overrides.json
+++ b/aws-codeartifact-repository/overrides.json
@@ -1,0 +1,40 @@
+{
+  "CREATE": {
+    "/PermissionsPolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "codeartifact:*",
+          "Resource": "*"
+        }
+      ]
+    },
+    "/Upstreams": null,
+    "/ExternalConnections": [
+      "public:npmjs"
+    ],
+    "/DomainOwner": null,
+    "/DomainName": "domain",
+    "/Description": "test description"
+  },
+  "UPDATE": {
+    "/PermissionsPolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "codeartifact:*",
+          "Resource": "*"
+        }
+      ]
+    },
+    "/Upstreams": null,
+    "/ExternalConnections": null,
+    "/DomainOwner": null,
+    "/DomainName": "domain",
+    "/Description": "test description"
+  }
+}

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ComparisonUtils.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ComparisonUtils.java
@@ -14,6 +14,11 @@ public class ComparisonUtils {
     public static boolean willNotUpdateDescription(final ResourceModel desiredModel, final ResourceModel prevModel) {
         return Objects.equals(prevModel.getDescription(), desiredModel.getDescription());
     }
+    public static boolean willUpdateCreateOnlyProperty(final ResourceModel desiredModel, final ResourceModel prevModel) {
+        return !Objects.equals(desiredModel.getRepositoryName(), prevModel.getRepositoryName()) ||
+            !Objects.equals(desiredModel.getDomainName(), prevModel.getDomainName()) ||
+            !Objects.equals(desiredModel.getDomainOwner(), prevModel.getDomainOwner());
+    }
 
     public static boolean upstreamsAreEqual(final ResourceModel desiredModel, final ResourceModel prevModel) {
         Set<String> prevUpstreamsSet = prevModel.getUpstreams() == null ? null :

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/DeleteHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/DeleteHandler.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -23,6 +24,7 @@ public class DeleteHandler extends BaseHandlerStd {
 
 
         this.logger = logger;
+        ResourceModel model = request.getDesiredResourceState();
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
             .then(progress ->
@@ -30,14 +32,22 @@ public class DeleteHandler extends BaseHandlerStd {
                     // STEP 2.1 [construct a body of a request]
                     .translateToServiceRequest(Translator::translateToDeleteRequest)
                     // STEP 2.2 [make an api call]
-                    .makeServiceCall((awsRequest, client) -> deleteRepository(progress, client, awsRequest))
+                    .makeServiceCall((awsRequest, client) -> {
+                        // if domain does not exist, deleteDomain does not throw an exception, so we must do this
+                        // to be under the ResourceHandler Contract
+                        if (!doesRepoExist(model, proxyClient)) {
+                            throw new CfnNotFoundException(model.getDomainName(), ResourceModel.TYPE_NAME);
+                        }
+                        return deleteRepository(progress, client, awsRequest);
+
+                    })
                     // STEP 2.3 [stabilize]
-                    .stabilize((awsRequest, awsResponse, client, model, context) -> repositoryIsDeleted(model, proxyClient))
-                    .success());
+                    .stabilize((awsRequest, awsResponse, client, resourceModel, context) -> !doesRepoExist(resourceModel, proxyClient))
+                    .done((awsRequest, response, client, resourceModel, context) -> ProgressEvent.success(null, context)));
     }
 
     private AwsResponse deleteRepository(
-        ProgressEvent<ResourceModel, CallbackContext>  progress,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
         ProxyClient<CodeartifactClient> client,
         DeleteRepositoryRequest awsRequest
     ) {
@@ -52,18 +62,16 @@ public class DeleteHandler extends BaseHandlerStd {
         return awsResponse;
     }
 
-    private boolean repositoryIsDeleted(
+    protected boolean doesRepoExist(
         final ResourceModel model,
         final ProxyClient<CodeartifactClient> proxyClient
     ) {
         try {
             proxyClient.injectCredentialsAndInvokeV2(
-                    Translator.translateToReadRequest(model), proxyClient.client()::describeRepository);
-            logger.log(String.format("%s successfully stabilized after deletion.", ResourceModel.TYPE_NAME));
-            return false;
-
-        } catch (ResourceNotFoundException e) {
+                Translator.translateToReadRequest(model), proxyClient.client()::describeRepository);
             return true;
+        } catch (ResourceNotFoundException e) {
+            return false;
         }
     }
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/DeleteHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/DeleteHandler.java
@@ -33,8 +33,8 @@ public class DeleteHandler extends BaseHandlerStd {
                     .translateToServiceRequest(Translator::translateToDeleteRequest)
                     // STEP 2.2 [make an api call]
                     .makeServiceCall((awsRequest, client) -> {
-                        // if domain does not exist, deleteDomain does not throw an exception, so we must do this
-                        // to be under the ResourceHandler Contract
+                        // if repository does not exist, deleteRepository does not throw an exception, so we must do
+                        // this to be under the ResourceHandler Contract
                         if (!doesRepoExist(model, proxyClient)) {
                             throw new CfnNotFoundException(model.getDomainName(), ResourceModel.TYPE_NAME);
                         }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -49,6 +49,7 @@ import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.codeartifact.repository.ResourceModel.ResourceModelBuilder;
 import org.apache.commons.collections.CollectionUtils;
 
 /**
@@ -129,7 +130,7 @@ public class Translator {
    */
   static ResourceModel translateFromReadResponse(final DescribeRepositoryResponse describeRepositoryResponse) {
     RepositoryDescription repositoryDescription = describeRepositoryResponse.repository();
-    ResourceModel resourceModelBuilder = ResourceModel.builder()
+    ResourceModelBuilder resourceModelBuilder = ResourceModel.builder()
         // TODO add repositoryEndpoint
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
@@ -137,14 +138,13 @@ public class Translator {
         .domainName(repositoryDescription.domainName())
         .domainOwner(repositoryDescription.domainOwner())
         .description(repositoryDescription.description())
-        .repositoryName(repositoryDescription.name())
-        .build();
+        .repositoryName(repositoryDescription.name());
 
     if (!CollectionUtils.isEmpty(repositoryDescription.upstreams())) {
-      resourceModelBuilder.setUpstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()));
+      resourceModelBuilder.upstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()));
     }
 
-    return resourceModelBuilder;
+    return resourceModelBuilder.build();
   }
 
   /**

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -49,6 +49,7 @@ import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import org.apache.commons.collections.CollectionUtils;
 
 /**
  * This class is a centralized placeholder for
@@ -128,18 +129,22 @@ public class Translator {
    */
   static ResourceModel translateFromReadResponse(final DescribeRepositoryResponse describeRepositoryResponse) {
     RepositoryDescription repositoryDescription = describeRepositoryResponse.repository();
-    return ResourceModel.builder()
-        // TODO add external connections and policy document
-        // https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-codeartifact/issues/18
+    ResourceModel resourceModelBuilder = ResourceModel.builder()
+        // TODO add repositoryEndpoint
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
         .administratorAccount(repositoryDescription.administratorAccount())
         .domainName(repositoryDescription.domainName())
-        .upstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()))
         .domainOwner(repositoryDescription.domainOwner())
         .description(repositoryDescription.description())
         .repositoryName(repositoryDescription.name())
         .build();
+
+    if (!CollectionUtils.isEmpty(repositoryDescription.upstreams())) {
+      resourceModelBuilder.setUpstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()));
+    }
+
+    return resourceModelBuilder;
   }
 
   /**

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/UpdateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/UpdateHandler.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermis
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.DisassociateExternalConnectionRequest;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -35,6 +36,11 @@ public class UpdateHandler extends BaseHandlerStd {
 
         final ResourceModel desiredModel = request.getDesiredResourceState();
         final ResourceModel prevModel = request.getPreviousResourceState();
+
+        if (ComparisonUtils.willUpdateCreateOnlyProperty(desiredModel, prevModel)) {
+            // CreateOnly fields cannot be updated
+            throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, desiredModel.getArn());
+        }
 
         ProgressEvent<ResourceModel, CallbackContext> updateRepositoryConnectionsEvent;
         if (ComparisonUtils.willAddUpstreams(desiredModel, prevModel)) {

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissio
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
+import software.amazon.awssdk.services.codeartifact.model.UpstreamRepositoryInfo;
 import software.amazon.awssdk.services.codeartifact.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
@@ -73,7 +74,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @AfterEach
     public void tear_down() {
-        verify(codeartifactClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(codeartifactClient);
     }
 
@@ -93,7 +93,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -129,6 +128,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -148,7 +148,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
+            .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -158,6 +158,10 @@ public class CreateHandlerTest extends AbstractTestBase {
             .administratorAccount(ADMIN_ACCOUNT)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
+            .upstreams(
+                UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_0).build(),
+                UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_1).build()
+            )
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
             .build();
@@ -185,6 +189,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
         verify(codeartifactClient, never()).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -213,7 +218,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -252,6 +256,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(capturedRequest.policyDocument()).isEqualTo(MAPPER.writeValueAsString(TEST_POLICY_DOC_0));
 
         verify(codeartifactClient, never()).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -280,7 +285,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -308,6 +312,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
         verify(codeartifactClient).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -355,6 +360,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, times(2)).describeRepository(any(DescribeRepositoryRequest.class));
         verify(codeartifactClient, times(2)).associateExternalConnection(any(AssociateExternalConnectionRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
 
@@ -379,6 +385,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
 
@@ -403,6 +410,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -426,6 +434,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
 
@@ -450,6 +459,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -473,6 +483,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -496,6 +507,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
     }
 
     @Test
@@ -518,6 +530,26 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(codeartifactClient).createRepository(any(CreateRepositoryRequest.class));
+        verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient, atLeastOnce()).serviceName();
+    }
+
+    @Test
+    public void handleRequest_invalidRequest_readOnlyProperties() {
+        final CreateHandler handler = new CreateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .administratorAccount("12345")
+            .repositoryName(REPO_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
         verify(codeartifactClient, never()).describeRepository(any(DescribeRepositoryRequest.class));
     }
 }

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
@@ -76,7 +76,6 @@ public class ReadHandlerTest extends AbstractTestBase {
         .domainName(DOMAIN_NAME)
         .domainOwner(DOMAIN_OWNER)
         .arn(REPO_ARN)
-        .upstreams(Collections.emptyList())
         .repositoryName(REPO_NAME)
         .description(DESCRIPTION)
         .administratorAccount(ADMIN_ACCOUNT)

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
@@ -78,6 +78,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .build();
 
@@ -86,7 +87,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -117,6 +117,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .build();
 
@@ -125,7 +126,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -155,6 +155,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
+            .repositoryName(REPO_NAME)
             .domainOwner(DOMAIN_OWNER)
             .build();
 
@@ -163,7 +164,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -194,6 +194,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
             .upstreams(UPSTREAMS)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .build();
@@ -247,6 +248,69 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_simpleSuccess_removeUpstreams() {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .build();
+
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .build();
+
+        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .previousResourceState(resourceModelWithUpstreams())
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        ArgumentCaptor<UpdateRepositoryRequest> updateRepositoryRequestArgumentCaptor =
+            ArgumentCaptor.forClass(UpdateRepositoryRequest.class);
+
+
+        assertSuccess(response, desiredOutputModel);
+
+        verify(codeartifactClient).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).updateRepository(updateRepositoryRequestArgumentCaptor.capture());
+
+        UpdateRepositoryRequest updateRepositoryRequest = updateRepositoryRequestArgumentCaptor.getValue();
+
+        assertThat(updateRepositoryRequest.upstreams()).isEmpty();
+        assertThat(updateRepositoryRequest.repository()).isEqualTo(REPO_NAME);
+        assertThat(updateRepositoryRequest.domain()).isEqualTo(DOMAIN_NAME);
+    }
+
+    @Test
     public void handleRequest_simpleSuccess_withNewExternalConnections() {
         final UpdateHandler handler = new UpdateHandler();
 
@@ -266,7 +330,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -324,7 +387,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
             //  paramter
@@ -393,7 +455,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
             //  paramter
@@ -449,7 +510,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
             //  paramter
@@ -598,7 +658,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -643,7 +702,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .administratorAccount(ADMIN_ACCOUNT)
             .build();
@@ -708,7 +766,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
             .arn(REPO_ARN)
-            .upstreams(Collections.emptyList())
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -727,20 +784,18 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .build();
     }
 
-    ResourceModel resourceModelWithNpmExternalConnection() {
+    ResourceModel resourceModelWithUpstreams() {
         return ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
+            .upstreams(UPSTREAMS)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
-            .externalConnections(Collections.singletonList(NPM_EC))
-            .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
     }
     ResourceModel resourceModel(Map<String, Object> policyDoc) {
         ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
+            .repositoryName(REPO_NAME)
             .domainOwner(DOMAIN_OWNER)
             .build();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Making sure contract tests pass:

* Testing* 

Results: 

```
➜  aws-codeartifact-repository git:(main) ✗ cfn test --enforce-timeout 120
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.7.8, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /usr/local/opt/python@3.7/bin/python3.7
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-repository/.hypothesis/examples')
rootdir: /Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-repository, inifile: /private/var/folders/n_/7tmz09ds2gv06hqgr5ry6sr8n8z_lw/T/pytest_oy4hkerv.ini
plugins: localserver-0.5.0, random-order-1.0.4, hypothesis-5.19.2
collected 16 items

handler_create.py::contract_create_delete PASSED                                                                                                         [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                        [ 12%]
handler_create.py::contract_create_duplicate SKIPPED                                                                                                     [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                   [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                   [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                           [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                           [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                         [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                         [ 56%]
handler_delete.py::contract_delete_create SKIPPED                                                                                                        [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                      [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                     [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                   [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                   [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                   [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
