### PR TITLE
Fixing GettAtt and Ref functions.

### DIFF
--- a/aws-codeartifact-domain/aws-codeartifact-domain.json
+++ b/aws-codeartifact-domain/aws-codeartifact-domain.json
@@ -19,26 +19,6 @@
       "description": "The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.",
       "type": "string"
     },
-    "CreatedTime": {
-      "description": "Timestamp of when the domain was created.",
-      "type": "string"
-    },
-    "RepositoryCount": {
-      "description": "The number of repositories in the domain.",
-      "type": "integer"
-    },
-    "AssetSizeBytes": {
-      "description": "The total size of all assets in the domain.",
-      "type": "integer"
-    },
-    "Status": {
-      "description": "The current status of a domain.",
-      "enum": [
-        "Active",
-        "Deleted"
-      ],
-      "type": "string"
-    },
     "PermissionsPolicyDocument": {
       "description": "The access control resource policy on the provided domain.",
       "type": "object",
@@ -61,10 +41,6 @@
     "/properties/EncryptionKey"
   ],
   "readOnlyProperties": [
-    "/properties/Arn",
-    "/properties/CreatedTime",
-    "/properties/RepositoryCount",
-    "/properties/AssetSizeBytes",
     "/properties/DomainOwner"
   ],
   "primaryIdentifier": [

--- a/aws-codeartifact-domain/pom.xml
+++ b/aws-codeartifact-domain/pom.xml
@@ -80,7 +80,12 @@
             <version>2.13.55</version>
         </dependency>
 
-
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <version>2.8.2</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/AbstractArn.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/AbstractArn.java
@@ -6,8 +6,9 @@ import com.google.common.base.MoreObjects;
 
 @Value.Immutable
 @Value.Style(allParameters = true, typeImmutable = "*", typeAbstract = "Abstract*")
-public abstract class AbstractDomainArn {
-    // TODO (jonjara) move this class to a common module
+public abstract class AbstractArn {
+    // TODO (jonjara) move this class to a common module and use it for both repositories and domains
+
     @Value.Default
     public String partition() {
         return "aws";
@@ -23,7 +24,9 @@ public abstract class AbstractDomainArn {
     // the type of the resource: "repository" or "domain"
     public abstract String type();
 
-    public abstract String domainName();
+    // the component from the Id of the resource without the type:
+    // "<domainName>/<resourceName>" or "<domainName>"
+    public abstract String shortId();
 
     public String arn() {
         StringBuilder sb = new StringBuilder().append("arn")
@@ -39,7 +42,7 @@ public abstract class AbstractDomainArn {
         return sb.append(":")
             .append(type())
             .append("/")
-            .append(domainName())
+            .append(shortId())
             .toString();
     }
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/AbstractDomainArn.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/AbstractDomainArn.java
@@ -1,0 +1,45 @@
+package software.amazon.codeartifact.domain;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.MoreObjects;
+
+@Value.Immutable
+@Value.Style(allParameters = true, typeImmutable = "*", typeAbstract = "Abstract*")
+public abstract class AbstractDomainArn {
+    // TODO (jonjara) move this class to a common module
+    @Value.Default
+    public String partition() {
+        return "aws";
+    }
+
+    public abstract String service();
+
+    public abstract String region();
+
+    // the accountId component of the ARN
+    public abstract String owner();
+
+    // the type of the resource: "repository" or "domain"
+    public abstract String type();
+
+    public abstract String domainName();
+
+    public String arn() {
+        StringBuilder sb = new StringBuilder().append("arn")
+            .append(":")
+            .append(partition())
+            .append(":")
+            .append(service())
+            .append(":")
+            .append(MoreObjects.firstNonNull(region(), ""))
+            .append(":")
+            .append(owner());
+
+        return sb.append(":")
+            .append(type())
+            .append("/")
+            .append(domainName())
+            .toString();
+    }
+}

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ArnUtils.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ArnUtils.java
@@ -3,14 +3,15 @@ package software.amazon.codeartifact.domain;
 public class ArnUtils {
     public static final String SERVICE_NAME = "codeartifact";
     public static final String DOMAIN_RESOURCE_TYPE = "domain";
+    public static final String REPO_RESOURCE_TYPE = "repository";
 
-    public static DomainArn fromArn(String arn) {
+
+    public static Arn fromArn(String arn) {
 
         // TODO (jonjara) move ArnUtils to a common module
         final int NUMBER_OF_ARN_FIELDS = 6;
         // Sample ARNs:
         // arn:aws:codeartifact:<region>:<domain-owner>:domain/<domain-name>
-        // arn:aws:codeartifact:<region>:<domain-owner>:repository/<domain-name>/<repo-name>
         String[] terms = arn.split(":", NUMBER_OF_ARN_FIELDS);
 
         String partition = terms[1];
@@ -22,26 +23,39 @@ public class ArnUtils {
         String resourceType = compoundName[0];
         String domainName = compoundName[1];
 
-        return DomainArn.builder()
+        return Arn.builder()
             .partition(partition)
             .region(region)
             .service(service)
             .owner(domainOwner)
             .type(resourceType)
-            .domainName(domainName)
+            .shortId(domainName)
             .build();
     }
 
-    public static DomainArn domainArn(
+    public static Arn domainArn(
         String partition, String region, String domainOwner, String domainName
     ) {
-        return DomainArn.builder()
+        return Arn.builder()
             .partition(partition)
             .region(region)
             .service(SERVICE_NAME)
             .owner(domainOwner)
             .type(DOMAIN_RESOURCE_TYPE)
-            .domainName(domainName)
+            .shortId(domainName)
+            .build();
+    }
+
+    public static Arn repoArn(
+        String partition, String region, String domainOwner, String domainName, String repoName
+    ) {
+        return Arn.builder()
+            .partition(partition)
+            .region(region)
+            .service(SERVICE_NAME)
+            .owner(domainOwner)
+            .type(REPO_RESOURCE_TYPE)
+            .shortId(String.format("%s/%s", domainName, repoName))
             .build();
     }
 

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ArnUtils.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ArnUtils.java
@@ -1,0 +1,48 @@
+package software.amazon.codeartifact.domain;
+
+public class ArnUtils {
+    public static final String SERVICE_NAME = "codeartifact";
+    public static final String DOMAIN_RESOURCE_TYPE = "domain";
+
+    public static DomainArn fromArn(String arn) {
+
+        // TODO (jonjara) move ArnUtils to a common module
+        final int NUMBER_OF_ARN_FIELDS = 6;
+        // Sample ARNs:
+        // arn:aws:codeartifact:<region>:<domain-owner>:domain/<domain-name>
+        // arn:aws:codeartifact:<region>:<domain-owner>:repository/<domain-name>/<repo-name>
+        String[] terms = arn.split(":", NUMBER_OF_ARN_FIELDS);
+
+        String partition = terms[1];
+        String service = terms[2];
+        String region = terms[3];
+        String domainOwner = terms[4];
+        String[] compoundName = terms[5].split("/", 2);
+
+        String resourceType = compoundName[0];
+        String domainName = compoundName[1];
+
+        return DomainArn.builder()
+            .partition(partition)
+            .region(region)
+            .service(service)
+            .owner(domainOwner)
+            .type(resourceType)
+            .domainName(domainName)
+            .build();
+    }
+
+    public static DomainArn domainArn(
+        String partition, String region, String domainOwner, String domainName
+    ) {
+        return DomainArn.builder()
+            .partition(partition)
+            .region(region)
+            .service(SERVICE_NAME)
+            .owner(domainOwner)
+            .type(DOMAIN_RESOURCE_TYPE)
+            .domainName(domainName)
+            .build();
+    }
+
+}

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
@@ -6,7 +6,6 @@ import software.amazon.awssdk.services.codeartifact.model.CreateDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.CreateDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -69,8 +68,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private boolean hasReadOnlyProperties(final ResourceModel model) {
-        return model.getAssetSizeBytes() != null || model.getRepositoryCount() != null
-            || model.getCreatedTime() != null || model.getDomainOwner() != null;
+        return model.getDomainOwner() != null;
     }
 
     private boolean isStabilized(

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
@@ -69,9 +69,9 @@ public class Translator {
 
     if (model.getArn() != null && domainName == null && domainOwner == null) {
       // This is the case GetAtt or Ref is called on the resource
-      DomainArn domainArn = ArnUtils.fromArn(model.getArn());
+      Arn domainArn = ArnUtils.fromArn(model.getArn());
 
-      domainName = domainArn.domainName();
+      domainName = domainArn.shortId();
       domainOwner = domainArn.owner();
     }
     return DescribeDomainRequest.builder()

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/AbstractTestBase.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/AbstractTestBase.java
@@ -5,6 +5,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -16,16 +19,14 @@ import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class AbstractTestBase {
   protected static final Credentials MOCK_CREDENTIALS;
   protected static final LoggerProxy logger;
-
   protected static final String DOMAIN_NAME = "test-domain-name";
-  protected static final String DOMAIN_ARN = "testDomainArn";
-  protected static final String ENCRYPTION_KEY_ARN = "testKeyArn";
+  protected static final String ENCRYPTION_KEY_ARN = "testKey/Arn";
   protected static final String DOMAIN_OWNER = "123456789";
+  protected static final String DOMAIN_ARN =
+      String.format("arn:aws:codeartifact:region:%s:domain/%s", DOMAIN_OWNER, DOMAIN_NAME);
   protected static final Map<String, Object> TEST_POLICY_DOC = Collections.singletonMap("key0", "value0");
   protected final Instant NOW = Instant.now();
   protected final int REPO_COUNT = 2;

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
@@ -9,6 +9,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +30,6 @@ import software.amazon.awssdk.services.codeartifact.model.CreateDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DomainDescription;
-import software.amazon.awssdk.services.codeartifact.model.GetDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
 import software.amazon.awssdk.services.codeartifact.model.PutDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.PutDomainPermissionsPolicyResponse;
@@ -44,8 +45,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -74,9 +73,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         .domainName(DOMAIN_NAME)
         .domainOwner(DOMAIN_OWNER)
         .arn(DOMAIN_ARN)
-        .repositoryCount(REPO_COUNT)
-        .createdTime(NOW.toString())
-        .assetSizeBytes(ASSET_SIZE)
         .encryptionKey(ENCRYPTION_KEY_ARN)
         .build();
 
@@ -134,7 +130,7 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_simpleSuccess_withEncrptionKey() {
+    public void handleRequest_simpleSuccess_withEncryptionKey() {
         final CreateHandler handler = new CreateHandler();
 
         final ResourceModel model = ResourceModel.builder()

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/DeleteHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/DeleteHandlerTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -31,7 +30,6 @@ import software.amazon.awssdk.services.codeartifact.model.InternalServerExceptio
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
-import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
@@ -58,10 +56,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
         .name(DOMAIN_NAME)
         .owner(DOMAIN_OWNER)
         .arn(DOMAIN_ARN)
-        .repositoryCount(REPO_COUNT)
-        .assetSizeBytes((long) ASSET_SIZE)
-        .status(STATUS)
-        .createdTime(NOW)
         .encryptionKey(ENCRYPTION_KEY_ARN)
         .build();
 

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/ListHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/ListHandlerTest.java
@@ -66,6 +66,8 @@ public class ListHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .awsPartition("aws")
+            .region("us-west-2")
             .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(ListDomainsRequest.class), any())).thenReturn(

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
@@ -1,17 +1,32 @@
 package software.amazon.codeartifact.domain;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
-import software.amazon.awssdk.services.codeartifact.model.CreateDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DeleteDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.DeleteDomainPermissionsPolicyResponse;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DomainDescription;
-import software.amazon.awssdk.services.codeartifact.model.GetDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.PutDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.PutDomainPermissionsPolicyResponse;
-import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ResourcePolicy;
 import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -19,25 +34,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest extends AbstractTestBase {
@@ -66,9 +62,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         .domainName(DOMAIN_NAME)
         .domainOwner(DOMAIN_OWNER)
         .arn(DOMAIN_ARN)
-        .repositoryCount(REPO_COUNT)
-        .createdTime(NOW.toString())
-        .assetSizeBytes(ASSET_SIZE)
         .encryptionKey(ENCRYPTION_KEY_ARN)
         .build();
 

--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -70,7 +70,6 @@
     "/properties/DomainOwner"
   ],
   "readOnlyProperties": [
-    "/properties/Arn",
     "/properties/AdministratorAccount"
   ],
   "primaryIdentifier": [

--- a/aws-codeartifact-repository/pom.xml
+++ b/aws-codeartifact-repository/pom.xml
@@ -78,7 +78,12 @@
       <artifactId>utils</artifactId>
       <version>2.13.59</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <version>2.8.2</version>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
 

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/AbstractRepositoryArn.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/AbstractRepositoryArn.java
@@ -1,0 +1,51 @@
+package software.amazon.codeartifact.repository;
+
+import org.immutables.value.Value;
+
+import com.google.common.base.MoreObjects;
+
+@Value.Immutable
+@Value.Style(allParameters = true, typeImmutable = "*", typeAbstract = "Abstract*")
+public abstract class AbstractRepositoryArn {
+    // TODO (jonjara) move this class to a common module
+
+    @Value.Default
+    public String partition() {
+        return "aws";
+    }
+
+    public abstract String service();
+
+    public abstract String region();
+
+    // the accountId component of the ARN
+    public abstract String owner();
+
+    // the type of the resource: "repository" or "domain"
+    public abstract String type();
+
+    public abstract String repoName();
+
+    public abstract String domainName();
+
+
+    public String arn() {
+        StringBuilder sb = new StringBuilder().append("arn")
+            .append(":")
+            .append(partition())
+            .append(":")
+            .append(service())
+            .append(":")
+            .append(MoreObjects.firstNonNull(region(), ""))
+            .append(":")
+            .append(owner());
+
+        return sb.append(":")
+            .append(type())
+            .append("/")
+            .append(domainName())
+            .append("/")
+            .append(repoName())
+            .toString();
+    }
+}

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ArnUtils.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ArnUtils.java
@@ -1,0 +1,34 @@
+package software.amazon.codeartifact.repository;
+
+public class ArnUtils {
+
+    public static RepositoryArn fromArn(String arn) {
+
+        // TODO (jonjara) move ArnUtils to a common module
+        final int NUMBER_OF_ARN_FIELDS = 6;
+        // Sample ARNs:
+        // arn:aws:codeartifact:<region>:<domain-owner>:repository/<domain-name>/<repo-name>
+        String[] terms = arn.split(":", NUMBER_OF_ARN_FIELDS);
+
+        String partition = terms[1];
+        String service = terms[2];
+        String region = terms[3];
+        String domainOwner = terms[4];
+        String[] compoundName = terms[5].split("/", 3);
+
+        String resourceType = compoundName[0];
+        String domainName = compoundName[1];
+        String repoName = compoundName[2];
+
+        return RepositoryArn.builder()
+            .partition(partition)
+            .region(region)
+            .service(service)
+            .owner(domainOwner)
+            .type(resourceType)
+            .domainName(domainName)
+            .repoName(repoName)
+            .build();
+    }
+
+}

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
@@ -63,7 +63,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private boolean hasReadOnlyProperties(final ResourceModel model) {
-        return model.getArn() != null || model.getAdministratorAccount() != null;
+        return model.getAdministratorAccount() != null;
     }
 
     private boolean isStabilized(

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -6,9 +6,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
-import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
@@ -19,19 +23,15 @@ import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
-import org.apache.commons.collections.map.HashedMap;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractTestBase {
   public static final ObjectMapper MAPPER = new ObjectMapper();
   protected static final String DOMAIN_NAME = "test-domain-name";
   protected static final String DOMAIN_OWNER = "12345";
   protected static final String ADMIN_ACCOUNT = "54321";
-  protected static final String REPO_ARN = "repoArn";
   protected static final String REPO_NAME = "test-repo-name";
+  protected static final String REPO_ARN = String.format("arn:aws:codeartifact:region:%s:repository/%s/%s",
+      DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
   protected static final Map<String, Object> TEST_POLICY_DOC_0 = Collections.singletonMap("key0", "value0");
   protected static final Map<String, Object> TEST_POLICY_DOC_1 = Collections.singletonMap("key1", "value1");
 

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ListHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ListHandlerTest.java
@@ -63,6 +63,8 @@ public class ListHandlerTest {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .awsPartition("aws")
+            .region("us-west-2")
             .build();
 
         when(proxy.injectCredentialsAndInvokeV2(any(ListRepositoriesRequest.class), any())).thenReturn(

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
@@ -1,24 +1,33 @@
 package software.amazon.codeartifact.repository;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
-import java.util.Collections;
-import software.amazon.awssdk.core.SdkClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.ConflictException;
-import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryRequest;
-import software.amazon.awssdk.services.codeartifact.model.DescribeDomainRequest;
-import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
-import software.amazon.awssdk.services.codeartifact.model.DomainDescription;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.codeartifact.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
@@ -28,22 +37,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
@@ -121,6 +114,46 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(codeartifactClient).describeRepository(any(DescribeRepositoryRequest.class));
+    }
+
+    @Test
+    public void handleRequest_simpleSuccess_onlyArn() {
+        final ReadHandler handler = new ReadHandler();
+
+        ResourceModel model = ResourceModel.builder()
+            .arn(REPO_ARN)
+            .build();
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .logicalResourceIdentifier(REPO_ARN)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        ArgumentCaptor<DescribeRepositoryRequest> argumentCaptor = ArgumentCaptor.forClass(DescribeRepositoryRequest.class);
+
+        verify(codeartifactClient).describeRepository(argumentCaptor.capture());
+
+        DescribeRepositoryRequest describeRepositoryRequest = argumentCaptor.getValue();
+
+        assertThat(describeRepositoryRequest.repository()).isEqualTo(REPO_NAME);
+        assertThat(describeRepositoryRequest.domain()).isEqualTo(DOMAIN_NAME);
+        assertThat(describeRepositoryRequest.domainOwner()).isEqualTo(DOMAIN_OWNER);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Apparently, `Ref` and `GetAtt` send model with *only* arn because its the primary identifier. Updating so the handlers can handler this scenario. 

Also removing some properties from schema's based on feedback from discussions.  I am removing `Arn` from readOnly because this conflicts with contract tests that prevent Create being called with readOnly properties, which does happen `GetAtt` is called in a create template. It's a bit intuitive..

The `ArnUtils` class should be shared between packages, I tried doing this but couldnt get maven to do what I wanted, so I am tabling this for later in the interest of time 

*Testing* 
`cfn submit` and deployed these stacks 

```

Parameters:
  Name:
    Type: String
Resources:
  TestCodeArtifactDomain:
    Type: 'AWS::CodeArtifact::Domain'
    Properties:
      DomainName: !Ref Name
Outputs:
  DomainOwner:
    Value: !GetAtt TestCodeArtifactDomain.DomainOwner
  Arn:
    Value: !Ref TestCodeArtifactDomain    

```

```
Parameters:
  Name:
    Type: String
  DomainName:
    Type: String    
Resources:
  TestCodeArtifacRepository:
    Type: 'AWS::CodeArtifact::Repository'
    Properties:
      RepositoryName: !Ref Name
      DomainName: !Ref DomainName

Outputs:
  Arn:
    Value: !Ref TestCodeArtifacRepository

  Admin:
    Value: !GetAtt TestCodeArtifacRepository.AdministratorAccount    

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
