### PR TITLE
Fixing creating repositories in other account's domain.

### DIFF
--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/CreateHandler.java
@@ -63,7 +63,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private boolean hasReadOnlyProperties(final ResourceModel model) {
-        return model.getAdministratorAccount() != null || model.getName() != null;
+        return model.getName() != null;
     }
 
     private boolean isStabilized(

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -544,7 +544,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .administratorAccount("12345")
+            .name(REPO_NAME)
             .repositoryName(REPO_NAME)
             .build();
 


### PR DESCRIPTION
*Description of changes:*

I had two accounts and I tried to create a repository in another account's domain and it failed because the request passes in `AdministratorAccount` which we were deeming invalid. This should not be invalid. 

**Testing**
Tested this on my account and it worked

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
