### PR TITLE
Pre-setting primaryResourceIdentifier.

### DIFF
--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ArnUtils.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ArnUtils.java
@@ -1,7 +1,8 @@
 package software.amazon.codeartifact.repository;
 
 public class ArnUtils {
-
+    public static final String SERVICE_NAME = "codeartifact";
+    public static final String REPO_RESOURCE_TYPE = "repository";
     public static RepositoryArn fromArn(String arn) {
 
         // TODO (jonjara) move ArnUtils to a common module
@@ -26,6 +27,20 @@ public class ArnUtils {
             .service(service)
             .owner(domainOwner)
             .type(resourceType)
+            .domainName(domainName)
+            .repoName(repoName)
+            .build();
+    }
+
+    public static RepositoryArn repoArn(
+        String partition, String region, String domainOwner, String domainName, String repoName
+    ) {
+        return RepositoryArn.builder()
+            .partition(partition)
+            .region(region)
+            .service(SERVICE_NAME)
+            .owner(domainOwner)
+            .type(REPO_RESOURCE_TYPE)
             .domainName(domainName)
             .repoName(repoName)
             .build();

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/BaseHandlerStd.java
@@ -3,6 +3,8 @@ package software.amazon.codeartifact.repository;
 import java.util.Set;
 
 import com.amazonaws.util.CollectionUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
@@ -14,9 +16,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     public static final ObjectMapper MAPPER = new ObjectMapper();

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -112,6 +112,7 @@ public class Translator {
     String repositoryName = model.getRepositoryName();
 
     if (model.getArn() != null && domainName == null && domainOwner == null && repositoryName == null) {
+      System.out.println("Read using only Arn");
         // this happens when Ref or GetAtt are called
         RepositoryArn repositoryArn = ArnUtils.fromArn(model.getArn());
 

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -112,7 +112,6 @@ public class Translator {
     String repositoryName = model.getRepositoryName();
 
     if (model.getArn() != null && domainName == null && domainOwner == null && repositoryName == null) {
-      System.out.println("Read using only Arn");
         // this happens when Ref or GetAtt are called
         RepositoryArn repositoryArn = ArnUtils.fromArn(model.getArn());
 

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -32,8 +32,8 @@ public class AbstractTestBase {
   protected static final String DOMAIN_OWNER = "12345";
   protected static final String ADMIN_ACCOUNT = "54321";
   protected static final String REPO_NAME = "test-repo-name";
-  protected static final String REPO_ARN = String.format("arn:aws:codeartifact:region:%s:repository/%s/%s",
-      DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
+  protected static final String REPO_ARN = String.format("arn:aws:codeartifact:%s:%s:repository/%s/%s",
+      REGION, DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
   protected static final Map<String, Object> TEST_POLICY_DOC_0 = Collections.singletonMap("key0", "value0");
   protected static final Map<String, Object> TEST_POLICY_DOC_1 = Collections.singletonMap("key1", "value1");
 

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -27,6 +27,8 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 public class AbstractTestBase {
   public static final ObjectMapper MAPPER = new ObjectMapper();
   protected static final String DOMAIN_NAME = "test-domain-name";
+  protected static final String PARTITION = "aws";
+  protected static final String REGION = "us-west-2";
   protected static final String DOMAIN_OWNER = "12345";
   protected static final String ADMIN_ACCOUNT = "54321";
   protected static final String REPO_NAME = "test-repo-name";

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -100,6 +100,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
@@ -170,6 +173,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         CreateRepositoryResponse createRepositoryResponse = CreateRepositoryResponse.builder()
@@ -227,6 +233,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         CreateRepositoryResponse createRepositoryResponse = CreateRepositoryResponse.builder()
@@ -295,6 +304,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         CreateRepositoryResponse createRepositoryResponse = CreateRepositoryResponse.builder()
@@ -342,6 +354,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         CreateRepositoryResponse createRepositoryResponse = CreateRepositoryResponse.builder()
@@ -383,6 +398,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnAlreadyExistsException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -408,6 +426,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnServiceLimitExceededException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -432,6 +453,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -457,6 +481,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnServiceInternalErrorException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -481,6 +508,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnAccessDeniedException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -505,6 +535,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnNotFoundException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -529,6 +562,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
@@ -550,6 +586,9 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .region(REGION)
+            .awsPartition(PARTITION)
+            .awsAccountId(DOMAIN_OWNER)
             .build();
 
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));


### PR DESCRIPTION
*Description of changes:*

Retries are not happening because of `Create handler did not return the primaryIdentifier for the physical resource.`.  The service was returning a 404 during stabilization but threw this error because the primaryIdentifier was not set yet. Setting before the chain prevents this from happening 

**Testing**

I submitted this on my personal account and stabilize retried as a expected when a 404 was returned.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
