### PR TITLE
Removing DomainOwner from Domain and AdministratorAccount from

### DIFF
--- a/aws-codeartifact-domain/aws-codeartifact-domain.json
+++ b/aws-codeartifact-domain/aws-codeartifact-domain.json
@@ -10,11 +10,6 @@
       "minLength": 2,
       "maxLength": 50
     },
-    "DomainOwner": {
-      "description": "The 12-digit account ID of the AWS account that owns the domain.",
-      "pattern": "[0-9]{12}",
-      "type": "string"
-    },
     "Name": {
       "description": "The name of the domain. This field is used for GetAtt",
       "type": "string",

--- a/aws-codeartifact-domain/inputs/inputs_1_create.json
+++ b/aws-codeartifact-domain/inputs/inputs_1_create.json
@@ -14,7 +14,6 @@
   "ExternalConnections": [
     "public:npmjs"
   ],
-  "DomainOwner": null,
   "DomainName": "create-contract-domain",
   "Description": "test description"
 }

--- a/aws-codeartifact-domain/inputs/inputs_1_update.json
+++ b/aws-codeartifact-domain/inputs/inputs_1_update.json
@@ -12,7 +12,6 @@
   },
   "Upstreams": null,
   "ExternalConnections": null,
-  "DomainOwner": null,
   "DomainName": "create-contract-domain",
   "Description": "test description"
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
@@ -68,7 +68,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     private boolean hasReadOnlyProperties(final ResourceModel model) {
-        return model.getDomainOwner() != null || model.getName() != null || model.getOwner() != null;
+        return model.getName() != null || model.getOwner() != null;
     }
 
     private boolean isStabilized(

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
@@ -62,7 +62,7 @@ public class Translator {
    */
   static DescribeDomainRequest translateToReadRequest(final ResourceModel model) {
     String domainName = model.getDomainName();
-    String domainOwner = model.getDomainOwner();
+    String domainOwner = model.getOwner();
 
     if (model.getArn() != null && domainName == null && domainOwner == null) {
       // This is the case GetAtt or Ref is called on the resource
@@ -88,7 +88,6 @@ public class Translator {
         .encryptionKey(domain.encryptionKey())
         .name(domain.name())
         .domainName(domain.name())
-        .domainOwner(domain.owner())
         .owner(domain.owner())
         .arn(domain.arn())
         .build();
@@ -102,7 +101,6 @@ public class Translator {
   static DeleteDomainRequest translateToDeleteRequest(final ResourceModel model) {
     return DeleteDomainRequest.builder()
         .domain(model.getDomainName())
-        .domainOwner(model.getDomainOwner())
         .build();
   }
 
@@ -115,7 +113,6 @@ public class Translator {
       try {
         return PutDomainPermissionsPolicyRequest.builder()
             .policyDocument(MAPPER.writeValueAsString(model.getPermissionsPolicyDocument()))
-            .domainOwner(model.getDomainOwner())
             .domain(model.getDomainName())
             .build();
       } catch (final JsonProcessingException e) {
@@ -130,7 +127,6 @@ public class Translator {
    */
   static DeleteDomainPermissionsPolicyRequest translateDeleteDomainPolicyRequest(final ResourceModel model) {
     return DeleteDomainPermissionsPolicyRequest.builder()
-        .domainOwner(model.getDomainOwner())
         .domain(model.getDomainName())
         .build();
   }

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
@@ -71,7 +71,6 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     private final ResourceModel desiredOutputModel = ResourceModel.builder()
         .domainName(DOMAIN_NAME)
-        .domainOwner(DOMAIN_OWNER)
         .name(DOMAIN_NAME)
         .owner(DOMAIN_OWNER)
         .arn(DOMAIN_ARN)

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/DeleteHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/DeleteHandlerTest.java
@@ -78,7 +78,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .build();
 
         DeleteDomainResponse deleteDomainResponse = DeleteDomainResponse.builder()

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/ReadHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/ReadHandlerTest.java
@@ -50,7 +50,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     private final ResourceModel model = ResourceModel.builder()
         .domainName(DOMAIN_NAME)
-        .domainOwner(DOMAIN_OWNER)
         .build();
 
     @BeforeEach
@@ -96,7 +95,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .owner(DOMAIN_OWNER)
             .name(DOMAIN_NAME)
             .arn(DOMAIN_ARN)
@@ -149,7 +147,6 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .name(DOMAIN_NAME)
             .owner(DOMAIN_OWNER)
             .arn(DOMAIN_ARN)

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
@@ -60,7 +60,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
     private final ResourceModel desiredOutputModel = ResourceModel.builder()
         .domainName(DOMAIN_NAME)
-        .domainOwner(DOMAIN_OWNER)
         .owner(DOMAIN_OWNER)
         .name(DOMAIN_NAME)
         .arn(DOMAIN_ARN)
@@ -85,13 +84,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .permissionsPolicyDocument(TEST_POLICY_DOC)
             .build();
 
         final ResourceModel previousModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .build();
 
         PutDomainPermissionsPolicyResponse putDomainPermissionsPolicyResponse = PutDomainPermissionsPolicyResponse.builder()
@@ -138,12 +135,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .build();
 
         final ResourceModel previousModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .permissionsPolicyDocument(TEST_POLICY_DOC)
             .build();
 
@@ -194,7 +189,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ResourceModel previousModel = ResourceModel.builder()
             .domainName("different-domain-name")
-            .domainOwner(DOMAIN_OWNER)
             .permissionsPolicyDocument(TEST_POLICY_DOC)
             .build();
 

--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -73,6 +73,8 @@
   ],
   "readOnlyProperties": [
     "/properties/Name",
+    "/properties/DomainName",
+    "/properties/DomainOwner",
     "/properties/Arn"
   ],
   "primaryIdentifier": [

--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -29,11 +29,6 @@
       "pattern": "[0-9]{12}",
       "type": "string"
     },
-    "AdministratorAccount": {
-      "description": "The 12-digit account ID of the AWS account that manages the repository.",
-      "pattern": "[0-9]{12}",
-      "type": "string"
-    },
     "Description": {
       "description": "A text description of the repository.",
       "type": "string",
@@ -78,8 +73,6 @@
   ],
   "readOnlyProperties": [
     "/properties/Name",
-    "/properties/DomainName",
-    "/properties/DomainOwner",
     "/properties/Arn"
   ],
   "primaryIdentifier": [

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -138,7 +138,6 @@ public class Translator {
         // TODO add repositoryEndpoint
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
-        .administratorAccount(repositoryDescription.administratorAccount())
         .domainName(repositoryDescription.domainName())
         .domainOwner(repositoryDescription.domainOwner())
         .description(repositoryDescription.description())

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -95,7 +95,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -152,7 +151,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -213,7 +211,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
@@ -286,7 +283,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -357,7 +353,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
@@ -72,7 +72,6 @@ public class ReadHandlerTest extends AbstractTestBase {
         .repositoryName(REPO_NAME)
         .name(REPO_NAME)
         .description(DESCRIPTION)
-        .administratorAccount(ADMIN_ACCOUNT)
         .build();
 
 

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
@@ -89,7 +89,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -129,7 +128,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -168,7 +166,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -223,7 +220,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -277,7 +273,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -337,7 +332,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -385,7 +379,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -398,7 +391,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
             //  paramter
 //            .externalConnections(Collections.singletonList(NPM_EC))
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -454,7 +446,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -467,7 +458,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
             //  paramter
 //            .externalConnections(Collections.singletonList(NPM_EC))
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -510,7 +500,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -523,7 +512,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
             //  paramter
 //            .externalConnections(Collections.singletonList(NPM_EC))
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -573,7 +561,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .externalConnections(Collections.singletonList(NPM_EC))
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -584,7 +571,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
@@ -660,7 +646,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .externalConnections(Collections.singletonList(NPM_EC))
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -670,7 +655,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -715,7 +699,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -792,7 +775,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .arn(REPO_ARN)
             .externalConnections(Collections.singletonList(PYPI_EC))
             .description(DESCRIPTION)
-            .administratorAccount(ADMIN_ACCOUNT)
             .build();
     }
 


### PR DESCRIPTION
Repository.

*Issue #, if available:*

*Description of changes:*

+ `DomainOwner` is not needed in Domain resource because we can't create domains in another accounts
+ `AdministratorAccount` is not needed in Repo resource because we are no longer exposing it to `GetAtt`

**Testing**
registered on my personal account and made sure i can create basic repo/domain plus create a repo in a domain owned by another account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
