### PR TITLE
Fixing contract tests for version 1.0.11

### DIFF
--- a/aws-codeartifact-domain/inputs/inputs_1_create.json
+++ b/aws-codeartifact-domain/inputs/inputs_1_create.json
@@ -1,4 +1,5 @@
 {
+  "DomainName": "create-contract-domain",
   "PermissionsPolicyDocument": {
     "Version": "2012-10-17",
     "Statement": [
@@ -9,11 +10,5 @@
         "Resource": "*"
       }
     ]
-  },
-  "Upstreams": null,
-  "ExternalConnections": [
-    "public:npmjs"
-  ],
-  "DomainName": "create-contract-domain",
-  "Description": "test description"
+  }
 }

--- a/aws-codeartifact-domain/inputs/inputs_1_update.json
+++ b/aws-codeartifact-domain/inputs/inputs_1_update.json
@@ -10,8 +10,5 @@
       }
     ]
   },
-  "Upstreams": null,
-  "ExternalConnections": null,
-  "DomainName": "create-contract-domain",
-  "Description": "test description"
+  "DomainName": "create-contract-domain"
 }

--- a/aws-codeartifact-domain/pom.xml
+++ b/aws-codeartifact-domain/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Constants.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Constants.java
@@ -6,6 +6,7 @@ public class Constants {
     public static final String LIST_DOMAINS = "codeartifact:ListDomains";
     public static final String PUT_DOMAIN_POLICY = "codeartifact:PutDomainPermissionsPolicy";
     public static final String DELETE_DOMAIN_PERMISSION_POLICY = "codeartifact:DeleteDomainPermissionsPolicy";
+    public static final String GET_DOMAIN_PERMISSION_POLICY = "codeartifact:GetDomainPermissionsPolicy";
     public static final String DELETE_DOMAIN = "codeartifact:DeleteDomain";
     public static final String DESCRIBE_DOMAIN = "codeartifact:DescribeDomain";
     public static final String ACTIVE_STATUS = "Active";

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ReadHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ReadHandler.java
@@ -3,6 +3,8 @@ package software.amazon.codeartifact.domain;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
+import software.amazon.awssdk.services.codeartifact.model.GetDomainPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -10,6 +12,7 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class ReadHandler extends BaseHandlerStd {
+
     private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -21,16 +24,58 @@ public class ReadHandler extends BaseHandlerStd {
 
         this.logger = logger;
 
-        ResourceModel model = request.getDesiredResourceState();
-        // STEP 1 [initialize a proxy context]
-        return proxy.initiate("AWS-CodeArtifact-Domain::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
+        logger.log(String.format("%s read handler is being invoked", ResourceModel.TYPE_NAME));
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+            .then(progress -> describeDomain(proxy, progress, request, proxyClient))
+            .then(progress -> getDomainPolicy(proxy, progress, request, proxyClient))
+            .then(progress -> {
+                final ResourceModel model = progress.getResourceModel();
+                return ProgressEvent.defaultSuccessHandler(model);
+            });
+    }
 
-            // STEP 2 [construct a body of a request]
-            .translateToServiceRequest(Translator::translateToReadRequest)
-            // STEP 3 [make an api call]
+    private ProgressEvent<ResourceModel, CallbackContext> getDomainPolicy(
+        AmazonWebServicesClientProxy proxy,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
+        ResourceHandlerRequest<ResourceModel> request,
+        ProxyClient<CodeartifactClient> proxyClient
+    ) {
+        return proxy.initiate("AWS-CodeArtifact-Domain::GetDomainPolicy", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+            .translateToServiceRequest(Translator::translateGetDomainPermissionsPolicyRequest)
             .makeServiceCall((awsRequest, client) -> {
-                logger.log(String.format("%s read handler is being invoked", ResourceModel.TYPE_NAME));
+                logger.log(String.format("%s getDomainPolicy is being invoked", ResourceModel.TYPE_NAME));
 
+                GetDomainPermissionsPolicyResponse getDomainPermissionsPolicyResponse = null;
+                try {
+                    getDomainPermissionsPolicyResponse = client.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::getDomainPermissionsPolicy);
+                } catch (final ResourceNotFoundException e) {
+                    // Do nothing since there is no policy
+                } catch (final AwsServiceException e) {
+                    String domainName = request.getDesiredResourceState().getDomainName();
+                    Translator.throwCfnException(e, Constants.GET_DOMAIN_PERMISSION_POLICY, domainName);
+                }
+                logger.log(String.format("Domain policy of %s has successfully been read.", ResourceModel.TYPE_NAME));
+                return getDomainPermissionsPolicyResponse;
+            })
+            .done((getDomainPermissionsPolicyRequest, getDomainPermissionsPolicyResponse, proxyInvocation, resourceModel, context) -> {
+                    if (getDomainPermissionsPolicyResponse != null) {
+                        String domainPolicy = getDomainPermissionsPolicyResponse.policy().document();
+                        resourceModel.setPermissionsPolicyDocument(Translator.deserializePolicy(domainPolicy));
+                    }
+                    return ProgressEvent.progress(resourceModel, context);
+                });
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> describeDomain(
+        AmazonWebServicesClientProxy proxy,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
+        ResourceHandlerRequest<ResourceModel> request,
+        ProxyClient<CodeartifactClient> proxyClient
+    ) {
+        return proxy.initiate("AWS-CodeArtifact-Domain::Read", proxyClient, progress.getResourceModel(), progress.getCallbackContext())
+            .translateToServiceRequest(Translator::translateToReadRequest)
+            .makeServiceCall((awsRequest, client) -> {
+                logger.log(String.format("%s describeDomain is being invoked", ResourceModel.TYPE_NAME));
                 DescribeDomainResponse awsResponse = null;
                 try {
                     awsResponse = client.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeDomain);
@@ -41,9 +86,7 @@ public class ReadHandler extends BaseHandlerStd {
                 logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));
                 return awsResponse;
             })
-            // STEP 4 [gather all properties of the resource]
-            .done(awsResponse ->
-                ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse, model))
-            );
+            .done((describeDomainRequest, describeDomainResponse, proxyInvocation, resourceModel, context) ->
+                ProgressEvent.progress(Translator.translateFromReadResponse(describeDomainResponse), context));
     }
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ReadHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ReadHandler.java
@@ -21,6 +21,7 @@ public class ReadHandler extends BaseHandlerStd {
 
         this.logger = logger;
 
+        ResourceModel model = request.getDesiredResourceState();
         // STEP 1 [initialize a proxy context]
         return proxy.initiate("AWS-CodeArtifact-Domain::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
 
@@ -41,13 +42,8 @@ public class ReadHandler extends BaseHandlerStd {
                 return awsResponse;
             })
             // STEP 4 [gather all properties of the resource]
-            .done(this::constructResourceModelFromResponse);
-    }
-
-    private ProgressEvent<ResourceModel, CallbackContext> constructResourceModelFromResponse(
-        final DescribeDomainResponse awsResponse
-    ) {
-        ResourceModel model = Translator.translateFromReadResponse(awsResponse);
-        return ProgressEvent.defaultSuccessHandler(model);
+            .done(awsResponse ->
+                ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse, model))
+            );
     }
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
@@ -2,6 +2,7 @@ package software.amazon.codeartifact.domain;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -82,9 +83,15 @@ public class Translator {
    * @param awsResponse the aws service describe resource response
    * @return model resource model
    */
-  static ResourceModel translateFromReadResponse(final DescribeDomainResponse awsResponse) {
+  static ResourceModel translateFromReadResponse(
+      final DescribeDomainResponse awsResponse, final ResourceModel model
+  ) {
+
+    Map<String, Object> permissionsPolicy = model.getPermissionsPolicyDocument();
+
     DomainDescription domain = awsResponse.domain();
     return ResourceModel.builder()
+        .permissionsPolicyDocument(permissionsPolicy)
         .encryptionKey(domain.encryptionKey())
         .name(domain.name())
         .domainName(domain.name())

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/Translator.java
@@ -1,13 +1,17 @@
 package software.amazon.codeartifact.domain;
 
+import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -19,6 +23,7 @@ import software.amazon.awssdk.services.codeartifact.model.DeleteDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DomainDescription;
+import software.amazon.awssdk.services.codeartifact.model.GetDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
 import software.amazon.awssdk.services.codeartifact.model.ListDomainsRequest;
 import software.amazon.awssdk.services.codeartifact.model.ListDomainsResponse;
@@ -29,6 +34,7 @@ import software.amazon.awssdk.services.codeartifact.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
@@ -79,19 +85,50 @@ public class Translator {
   }
 
   /**
+   * Request to get permissionsPolicy of the domain resource
+   * @param model resource model
+   * @return awsRequest the aws service request to describe a resource
+   */
+  static GetDomainPermissionsPolicyRequest translateGetDomainPermissionsPolicyRequest(final ResourceModel model) {
+    String domainName = model.getDomainName();
+    String domainOwner = model.getOwner();
+
+    if (model.getArn() != null && domainName == null && domainOwner == null) {
+      // This is the case GetAtt or Ref is called on the resource
+      Arn domainArn = ArnUtils.fromArn(model.getArn());
+
+      domainName = domainArn.shortId();
+      domainOwner = domainArn.owner();
+    }
+    return GetDomainPermissionsPolicyRequest.builder()
+        .domain(domainName)
+        .domainOwner(domainOwner)
+        .build();
+  }
+
+  public static Map<String, Object> deserializePolicy(final String policy) {
+    if (StringUtils.isNullOrEmpty(policy)) {
+      return null;
+    }
+
+    try {
+      return MAPPER.readValue(policy, new TypeReference<HashMap<String,Object>>() {});
+    } catch (final IOException e) {
+      throw new CfnInternalFailureException(e);
+    }
+  }
+
+  /**
    * Translates resource object from sdk into a resource model
    * @param awsResponse the aws service describe resource response
    * @return model resource model
    */
   static ResourceModel translateFromReadResponse(
-      final DescribeDomainResponse awsResponse, final ResourceModel model
+      final DescribeDomainResponse awsResponse
   ) {
-
-    Map<String, Object> permissionsPolicy = model.getPermissionsPolicyDocument();
 
     DomainDescription domain = awsResponse.domain();
     return ResourceModel.builder()
-        .permissionsPolicyDocument(permissionsPolicy)
         .encryptionKey(domain.encryptionKey())
         .name(domain.name())
         .domainName(domain.name())

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
@@ -210,6 +210,16 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .name(DOMAIN_NAME)
+            .owner(DOMAIN_OWNER)
+            .permissionsPolicyDocument(TEST_POLICY_DOC)
+            .arn(DOMAIN_ARN)
+            .encryptionKey(ENCRYPTION_KEY_ARN)
+            .build();
+
         assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
@@ -117,6 +117,16 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .permissionsPolicyDocument(TEST_POLICY_DOC)
+            .owner(DOMAIN_OWNER)
+            .name(DOMAIN_NAME)
+            .arn(DOMAIN_ARN)
+            .encryptionKey(ENCRYPTION_KEY_ARN)
+            .build();
+
         assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/UpdateHandlerTest.java
@@ -25,8 +25,11 @@ import software.amazon.awssdk.services.codeartifact.model.DeleteDomainPermission
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeDomainResponse;
 import software.amazon.awssdk.services.codeartifact.model.DomainDescription;
+import software.amazon.awssdk.services.codeartifact.model.GetDomainPermissionsPolicyRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetDomainPermissionsPolicyResponse;
 import software.amazon.awssdk.services.codeartifact.model.PutDomainPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.PutDomainPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ResourcePolicy;
 import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -105,6 +108,15 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domain(domainDescription)
             .build();
 
+        GetDomainPermissionsPolicyResponse getDomainPermissionsPolicyResponse = GetDomainPermissionsPolicyResponse.builder()
+            .policy(
+                ResourcePolicy.builder()
+                    .document(MAPPER.writeValueAsString(TEST_POLICY_DOC))
+                    .build()
+            )
+            .build();
+
+        when(proxyClient.client().getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class))).thenReturn(getDomainPermissionsPolicyResponse);
         when(proxyClient.client().describeDomain(any(DescribeDomainRequest.class))).thenReturn(describeDomainResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -167,6 +179,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domain(domainDescription)
             .build();
 
+        when(proxyClient.client().getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().describeDomain(any(DescribeDomainRequest.class))).thenReturn(describeDomainResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-codeartifact-repository/inputs/inputs_1_create.json
+++ b/aws-codeartifact-repository/inputs/inputs_1_create.json
@@ -10,12 +10,10 @@
       }
     ]
   },
-  "Upstreams": null,
   "ExternalConnections": [
     "public:npmjs"
   ],
   "RepositoryName": "repo-contract-test",
-  "DomainOwner": null,
   "Description": "description",
   "DomainName": "domain"
 }

--- a/aws-codeartifact-repository/inputs/inputs_1_invalid.json
+++ b/aws-codeartifact-repository/inputs/inputs_1_invalid.json
@@ -10,9 +10,6 @@
       }
     ]
   },
-  "Upstreams": null,
-  "ExternalConnections": null,
-  "DomainOwner": null,
   "Description": "description",
   "DomainName": "domain",
   "Name": "repo-contract-test",

--- a/aws-codeartifact-repository/inputs/inputs_1_update.json
+++ b/aws-codeartifact-repository/inputs/inputs_1_update.json
@@ -10,8 +10,6 @@
       }
     ]
   },
-  "Upstreams": null,
-  "ExternalConnections": null,
   "Description": "description",
   "RepositoryName": "repo-contract-test",
   "DomainName": "domain"

--- a/aws-codeartifact-repository/pom.xml
+++ b/aws-codeartifact-repository/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>software.amazon.cloudformation</groupId>
       <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.2</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
     <dependency>

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
     public static final String DELETE_REPOSITORY = "codeartifact:DeleteRepository";
     public static final String PUT_REPOSITORY_POLICY = "codeartifact:PutRepositoryPermissionsPolicy";
     public static final String DELETE_REPOSITORY_POLICY = "codeartifact:DeleteRepositoryPermissionsPolicy";
+    public static final String GET_REPOSITORY_PERMISSION_POLICY = "codeartifact:GetRepositoryPermissionsPolicy";
     public static final String ASSOCIATE_EXTERNAL_CONNECTION = "codeartifact:AssociateExternalConnection";
     public static final String LIST_REPOSITORIES = "codeartifact:ListRepositories";
     public static final String DISASSOCIATE_EXTERNAL_CONNECTION = "codeartifact:DisassociateExternalConnection";

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ReadHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ReadHandler.java
@@ -3,6 +3,8 @@ package software.amazon.codeartifact.repository;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyResponse;
+import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -21,12 +23,61 @@ public class ReadHandler extends BaseHandlerStd {
 
         this.logger = logger;
 
-        ResourceModel model = request.getDesiredResourceState();
         // STEP 1 [initialize a proxy context]
-        return proxy.initiate("AWS-CodeArtifact-Domain::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
-            // STEP 2 [construct a body of a request]
+        logger.log(String.format("%s read handler is being invoked", ResourceModel.TYPE_NAME));
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+            .then(progress -> describeRepository(proxy, progress, request, proxyClient))
+            .then(progress -> getRepositoryPolicy(proxy, progress, request, proxyClient))
+            .then(progress -> {
+                final ResourceModel model = progress.getResourceModel();
+                return ProgressEvent.defaultSuccessHandler(model);
+            });
+
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> getRepositoryPolicy(
+        AmazonWebServicesClientProxy proxy,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
+        ResourceHandlerRequest<ResourceModel> request,
+        ProxyClient<CodeartifactClient> proxyClient
+    ) {
+        return proxy.initiate("AWS-CodeArtifact-Repository::GetRepositoryPolicy", proxyClient,
+            progress.getResourceModel(),
+            progress.getCallbackContext())
+            .translateToServiceRequest(Translator::translateToGetRepositoryPermissionsPolicy)
+            .makeServiceCall((awsRequest, client) -> {
+                logger.log(String.format("%s getRepositoryPolicy is being invoked", ResourceModel.TYPE_NAME));
+                GetRepositoryPermissionsPolicyResponse getRepositoryPermissionsPolicyResponse = null;
+                try {
+                    getRepositoryPermissionsPolicyResponse = client.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::getRepositoryPermissionsPolicy);
+                } catch (final ResourceNotFoundException e) {
+                    // Do nothing since there is no policy
+                } catch (final AwsServiceException e) {
+                    String repositoryName = request.getDesiredResourceState().getRepositoryName();
+                    Translator.throwCfnException(e, Constants.GET_REPOSITORY_PERMISSION_POLICY, repositoryName);
+                }
+                logger.log(String.format("Repository policy of %s has successfully been read.", ResourceModel.TYPE_NAME));
+                return getRepositoryPermissionsPolicyResponse;
+            })
+            .done((getRepositoryPermissionsPolicyRequest, getRepositoryPermissionsPolicyResponse, proxyInvocation, resourceModel, context) -> {
+                if (getRepositoryPermissionsPolicyResponse != null) {
+                    String repositoryPolicy = getRepositoryPermissionsPolicyResponse.policy().document();
+                    resourceModel.setPermissionsPolicyDocument(Translator.deserializePolicy(repositoryPolicy));
+                }
+                return ProgressEvent.progress(resourceModel, context);
+            });
+
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> describeRepository(
+        AmazonWebServicesClientProxy proxy,
+        ProgressEvent<ResourceModel, CallbackContext> progress,
+        ResourceHandlerRequest<ResourceModel> request,
+        ProxyClient<CodeartifactClient> proxyClient
+    ) {
+        return proxy.initiate("AWS-CodeArtifact-Repository::Repository", proxyClient, progress.getResourceModel(),
+            progress.getCallbackContext())
             .translateToServiceRequest(Translator::translateToReadRequest)
-            // STEP 3 [make an api call]
             .makeServiceCall((awsRequest, client) -> {
                 DescribeRepositoryResponse awsResponse = null;
                 try {
@@ -38,9 +89,7 @@ public class ReadHandler extends BaseHandlerStd {
                 logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));
                 return awsResponse;
             })
-            // STEP 4 [gather all properties of the resource]
-            .done(awsResponse ->
-                ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse, model))
-            );
+            .done((describeRepositoryRequest, describeRepositoryResponse, proxyInvocation, resourceModel, context) ->
+                ProgressEvent.progress(Translator.translateFromReadResponse(describeRepositoryResponse), context));
     }
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ReadHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ReadHandler.java
@@ -21,6 +21,7 @@ public class ReadHandler extends BaseHandlerStd {
 
         this.logger = logger;
 
+        ResourceModel model = request.getDesiredResourceState();
         // STEP 1 [initialize a proxy context]
         return proxy.initiate("AWS-CodeArtifact-Domain::Read", proxyClient, request.getDesiredResourceState(), callbackContext)
             // STEP 2 [construct a body of a request]
@@ -38,6 +39,8 @@ public class ReadHandler extends BaseHandlerStd {
                 return awsResponse;
             })
             // STEP 4 [gather all properties of the resource]
-            .done(awsResponse -> ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse)));
+            .done(awsResponse ->
+                ProgressEvent.defaultSuccessHandler(Translator.translateFromReadResponse(awsResponse, model))
+            );
     }
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -4,6 +4,7 @@ import org.apache.commons.collections.CollectionUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -132,10 +133,17 @@ public class Translator {
    * @param describeRepositoryResponse the aws service describe resource response
    * @return model resource model
    */
-  static ResourceModel translateFromReadResponse(final DescribeRepositoryResponse describeRepositoryResponse) {
+  static ResourceModel translateFromReadResponse(
+      final DescribeRepositoryResponse describeRepositoryResponse, ResourceModel model
+  ) {
     RepositoryDescription repositoryDescription = describeRepositoryResponse.repository();
+
+    List<String> externalConnections = model.getExternalConnections();
+    Map<String, Object> permissionsPolicy = model.getPermissionsPolicyDocument();
+
     ResourceModelBuilder resourceModelBuilder = ResourceModel.builder()
-        // TODO add repositoryEndpoint
+        .externalConnections(externalConnections)
+        .permissionsPolicyDocument(permissionsPolicy)
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
         .domainName(repositoryDescription.domainName())

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -1,8 +1,10 @@
 package software.amazon.codeartifact.repository;
 
 import org.apache.commons.collections.CollectionUtils;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -10,7 +12,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -29,6 +33,7 @@ import software.amazon.awssdk.services.codeartifact.model.ListRepositoriesReques
 import software.amazon.awssdk.services.codeartifact.model.ListRepositoriesResponse;
 import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryRequest;
@@ -38,6 +43,7 @@ import software.amazon.awssdk.services.codeartifact.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
@@ -103,6 +109,20 @@ public class Translator {
   }
 
   /**
+   * Translates repositoryDescription to list of strings
+   * @param repositoryDescription repo description
+   * @return list of externalConnectionName strings
+   */
+  static List<String> translateToExternalConnectionsFromRepositoryExternalConnectionInfo(
+      final RepositoryDescription repositoryDescription
+  ) {
+    return streamOfOrEmpty(repositoryDescription.externalConnections())
+        .map(RepositoryExternalConnectionInfo::externalConnectionName)
+        .collect(Collectors.toList());
+  }
+
+
+  /**
    * Request to read a resource
    * @param model resource model
    * @return awsRequest the aws service request to describe a resource
@@ -134,16 +154,11 @@ public class Translator {
    * @return model resource model
    */
   static ResourceModel translateFromReadResponse(
-      final DescribeRepositoryResponse describeRepositoryResponse, ResourceModel model
+      final DescribeRepositoryResponse describeRepositoryResponse
   ) {
+
     RepositoryDescription repositoryDescription = describeRepositoryResponse.repository();
-
-    List<String> externalConnections = model.getExternalConnections();
-    Map<String, Object> permissionsPolicy = model.getPermissionsPolicyDocument();
-
     ResourceModelBuilder resourceModelBuilder = ResourceModel.builder()
-        .externalConnections(externalConnections)
-        .permissionsPolicyDocument(permissionsPolicy)
         .arn(repositoryDescription.arn())
         .description(repositoryDescription.description())
         .domainName(repositoryDescription.domainName())
@@ -153,7 +168,13 @@ public class Translator {
         .name(repositoryDescription.name());
 
     if (!CollectionUtils.isEmpty(repositoryDescription.upstreams())) {
-      resourceModelBuilder.upstreams(translateToUpstreamsFromRepoDescription(describeRepositoryResponse.repository()));
+      resourceModelBuilder.upstreams(translateToUpstreamsFromRepoDescription(repositoryDescription));
+    }
+
+    if (!CollectionUtils.isEmpty(repositoryDescription.externalConnections())) {
+      resourceModelBuilder.externalConnections(
+          translateToExternalConnectionsFromRepositoryExternalConnectionInfo(repositoryDescription)
+      );
     }
 
     return resourceModelBuilder.build();
@@ -200,10 +221,24 @@ public class Translator {
    * @return awsRequest the aws service request to describe a policy
    */
   static GetRepositoryPermissionsPolicyRequest translateToGetRepositoryPermissionsPolicy(final ResourceModel model) {
+
+    String domainName = model.getDomainName();
+    String domainOwner = model.getDomainOwner();
+    String repositoryName = model.getRepositoryName();
+
+    if (model.getArn() != null && domainName == null && domainOwner == null && repositoryName == null) {
+      // this happens when Ref or GetAtt are called
+      RepositoryArn repositoryArn = ArnUtils.fromArn(model.getArn());
+
+      domainName = repositoryArn.domainName();
+      domainOwner = repositoryArn.owner();
+      repositoryName = repositoryArn.repoName();
+    }
+
     return GetRepositoryPermissionsPolicyRequest.builder()
-        .domain(model.getDomainName())
-        .repository(model.getRepositoryName())
-        .domainOwner(model.getDomainOwner())
+        .domain(domainName)
+        .repository(repositoryName)
+        .domainOwner(domainOwner)
         .build();
   }
 
@@ -317,6 +352,17 @@ public class Translator {
         .orElseGet(Stream::empty);
   }
 
+  public static Map<String, Object> deserializePolicy(final String policy) {
+    if (StringUtils.isNullOrEmpty(policy)) {
+      return null;
+    }
+    try {
+      return MAPPER.readValue(policy, new TypeReference<HashMap<String,Object>>() {});
+    } catch (final IOException e) {
+      throw new CfnInternalFailureException(e);
+    }
+  }
+
   static void throwCfnException(final AwsServiceException exception, String operation, String repositoryName) {
     if (exception instanceof AccessDeniedException) {
       throw new CfnAccessDeniedException(exception);
@@ -338,5 +384,6 @@ public class Translator {
     }
     throw new CfnGeneralServiceException(exception);
   }
+
 
 }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/UpdateHandler.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/UpdateHandler.java
@@ -1,6 +1,5 @@
 package software.amazon.codeartifact.repository;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -11,7 +10,6 @@ import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermissionsPolicyResponse;
-import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.DisassociateExternalConnectionRequest;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -281,6 +281,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
+            .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
             .build();
@@ -350,6 +351,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -33,10 +33,14 @@ import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryReques
 import software.amazon.awssdk.services.codeartifact.model.CreateRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyResponse;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
 import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.codeartifact.model.ResourcePolicy;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.codeartifact.model.UpstreamRepositoryInfo;
 import software.amazon.awssdk.services.codeartifact.model.ValidationException;
@@ -117,6 +121,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().createRepository(any(CreateRepositoryRequest.class))).thenReturn(createRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -173,6 +178,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().createRepository(any(CreateRepositoryRequest.class))).thenReturn(createRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -243,6 +249,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -297,6 +304,16 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        GetRepositoryPermissionsPolicyResponse getRepositoryPermissionsPolicyResponse = GetRepositoryPermissionsPolicyResponse.builder()
+            .policy(
+                ResourcePolicy.builder()
+                    .document(MAPPER.writeValueAsString(TEST_POLICY_DOC_0))
+                    .build()
+            )
+            .build();
+
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenReturn(getRepositoryPermissionsPolicyResponse);
+
         when(proxyClient.client().createRepository(any(CreateRepositoryRequest.class))).thenReturn(createRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -343,6 +360,13 @@ public class CreateHandlerTest extends AbstractTestBase {
             .administratorAccount(ADMIN_ACCOUNT)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                    .externalConnectionName(NPM_EC)
+                    .build()
+                )
+            )
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
             .build();
@@ -368,6 +392,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().createRepository(any(CreateRepositoryRequest.class))).thenReturn(createRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -394,7 +419,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .externalConnections(Arrays.asList("public:npmjs", "public:pypi"))
+            .externalConnections(Arrays.asList(NPM_EC, PYPI_EC))
             .description(DESCRIPTION)
             .build();
 
@@ -418,6 +443,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().createRepository(any(CreateRepositoryRequest.class))).thenReturn(createRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
@@ -86,6 +86,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
+            .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
@@ -125,6 +126,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
+            .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
@@ -196,7 +198,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .upstreams(UPSTREAMS)
-            .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .build();
 
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
@@ -329,6 +330,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
@@ -388,9 +390,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
-            //  paramter
-//            .externalConnections(Collections.singletonList(NPM_EC))
+            .externalConnections(Collections.singletonList(NPM_EC))
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -455,9 +455,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
-            //  paramter
-//            .externalConnections(Collections.singletonList(NPM_EC))
+            .externalConnections(Collections.singletonList(NPM_EC))
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -509,9 +507,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .arn(REPO_ARN)
             .description(DESCRIPTION)
-            // TODO(jonjara)this would be true but we need to update the ReadHandler to populate ExternalConnection
-            //  paramter
-//            .externalConnections(Collections.singletonList(NPM_EC))
+            .externalConnections(Collections.singletonList(NPM_EC))
             .build();
 
         UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
@@ -653,6 +649,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
+
             .arn(REPO_ARN)
             .description(DESCRIPTION)
             .build();
@@ -697,6 +695,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
+            .externalConnections(Collections.singletonList(NPM_EC))
             .arn(REPO_ARN)
             .description(DESCRIPTION)
             .build();

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
@@ -31,8 +31,12 @@ import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryPermis
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.DisassociateExternalConnectionRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyRequest;
+import software.amazon.awssdk.services.codeartifact.model.GetRepositoryPermissionsPolicyResponse;
 import software.amazon.awssdk.services.codeartifact.model.PutRepositoryPermissionsPolicyRequest;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
+import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
+import software.amazon.awssdk.services.codeartifact.model.ResourcePolicy;
 import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.UpstreamRepository;
@@ -96,6 +100,15 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+        GetRepositoryPermissionsPolicyResponse getRepositoryPermissionsPolicyResponse = GetRepositoryPermissionsPolicyResponse.builder()
+            .policy(
+                ResourcePolicy.builder()
+                    .document(MAPPER.writeValueAsString(TEST_POLICY_DOC_0))
+                    .build()
+            )
+            .build();
+
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenReturn(getRepositoryPermissionsPolicyResponse);
         when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -136,6 +149,16 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repository(repositoryDescription)
             .build();
 
+
+        GetRepositoryPermissionsPolicyResponse getRepositoryPermissionsPolicyResponse = GetRepositoryPermissionsPolicyResponse.builder()
+            .policy(
+                ResourcePolicy.builder()
+                    .document(MAPPER.writeValueAsString(TEST_POLICY_DOC_0))
+                    .build()
+            )
+            .build();
+
+        when(proxyClient.client().getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class))).thenReturn(getRepositoryPermissionsPolicyResponse);
         when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -223,11 +246,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .description(DESCRIPTION)
             .build();
 
-        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+        UpdateRepositoryResponse updateRepositoryResponse = UpdateRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
 
-        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updateRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
@@ -276,11 +299,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .description(DESCRIPTION)
             .build();
 
-        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+        UpdateRepositoryResponse updateRepositoryResponse = UpdateRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
 
-        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updateRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
@@ -323,8 +346,21 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .description(DESCRIPTION)
             .build();
 
-        // describe repo response has no external connections, we need to add the one in the Resourcemodel
-        final RepositoryDescription repositoryDescription = RepoInfoWithOutExternalConnections();
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                        .externalConnectionName(NPM_EC)
+                        .build()
+                )
+            )
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
@@ -336,11 +372,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .description(DESCRIPTION)
             .build();
 
-        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+        UpdateRepositoryResponse updateRepositoryResponse = UpdateRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
 
-        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updateRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
@@ -393,11 +429,27 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .externalConnections(Collections.singletonList(NPM_EC))
             .build();
 
-        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                        .externalConnectionName(NPM_EC)
+                        .build()
+                )
+            )
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+
+        UpdateRepositoryResponse updateRepositoryResponse = UpdateRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
 
-        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updateRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
@@ -458,6 +510,22 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .externalConnections(Collections.singletonList(NPM_EC))
             .build();
 
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                        .externalConnectionName(NPM_EC)
+                        .build()
+                )
+            )
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
@@ -510,11 +578,28 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .externalConnections(Collections.singletonList(NPM_EC))
             .build();
 
-        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+        UpdateRepositoryResponse updateRepositoryResponse = UpdateRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
 
-        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updateRepositoryResponse);
+
+
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                        .externalConnectionName(NPM_EC)
+                        .build()
+                )
+            )
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
@@ -582,11 +667,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .build();
 
-        UpdateRepositoryResponse updatePackageVersionsStatusResponse = UpdateRepositoryResponse.builder()
+        UpdateRepositoryResponse updateRepositoryResponse = UpdateRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
 
-        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updatePackageVersionsStatusResponse);
+        when(proxyClient.client().updateRepository(any(UpdateRepositoryRequest.class))).thenReturn(updateRepositoryResponse);
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
@@ -634,8 +719,24 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .description(DESCRIPTION)
             .build();
 
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                        .externalConnectionName(NPM_EC)
+                        .build()
+                )
+            )
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+
         // describe repo response has no external connections, we need to add the one in the Resourcemodel
-        final ResourceModel prevModelWithNpmEc =  ResourceModel.builder()
+        final ResourceModel prevModelWithNpmEc = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
@@ -700,9 +801,26 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .description(DESCRIPTION)
             .build();
 
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(REPO_ARN)
+            .description(DESCRIPTION)
+            .externalConnections(
+                Collections.singletonList(
+                    RepositoryExternalConnectionInfo.builder()
+                        .externalConnectionName(NPM_EC)
+                        .build()
+                )
+            )
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
+            .build();
+
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
             .repository(repositoryDescription)
             .build();
+
 
         when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
         // this happens when permission policy is stabilized


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating for `1.0.11` of `cloudformation-cli` and `2.02` of `cloudformation-cli-java-plugin`



**Testing**
```
============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.7.8, pytest-6.1.0, py-1.9.0, pluggy-0.13.1 -- /usr/local/opt/python@3.7/bin/python3.7
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-repository/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-repository, configfile: ../../../../../private/var/folders/n_/7tmz09ds2gv06hqgr5ry6sr8n8z_lw/T/pytest_78pxge76.ini
plugins: hypothesis-5.36.2, localserver-0.5.0, random-order-1.0.4
collected 16 items

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                           [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                          [ 12%]
handler_create.py::contract_create_duplicate SKIPPED                                                                                                                                                                                       [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                     [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                     [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                             [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                             [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                           [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                           [ 56%]
handler_delete.py::contract_delete_create SKIPPED                                                                                                                                                                                          [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                        [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                       [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                     [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                     [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                     [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                    [100%]



aws-codeartifact-domain

============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.7.8, pytest-6.1.0, py-1.9.0, pluggy-0.13.1 -- /usr/local/opt/python@3.7/bin/python3.7
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-domain/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-domain, configfile: ../../../../../private/var/folders/n_/7tmz09ds2gv06hqgr5ry6sr8n8z_lw/T/pytest_fo_rg358.ini
plugins: hypothesis-5.36.2, localserver-0.5.0, random-order-1.0.4
collected 16 items

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                           [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                          [ 12%]
handler_create.py::contract_create_duplicate SKIPPED                                                                                                                                                                                       [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                     [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                     [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                             [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                             [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                           [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                           [ 56%]
handler_delete.py::contract_delete_create SKIPPED                                                                                                                                                                                          [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                        [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                       [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                     [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                     [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                     [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                    [100%]

=================================================================================================== 14 passed, 2 skipped in 1020.33s (0:17:00) ===================================================================================================
➜  aws-codeartifact-domain git:(prop-2) ✗ pip3 freeze | grep cloudformation
cloudformation-cli==0.1.11
cloudformation-cli-go-plugin==2.0.0
cloudformation-cli-java-plugin==2.0.2
cloudformation-cli-python-plugin==2.1.0
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
