### PR TITLE
Updating DeleteHandler to nullify model only on success.

### DIFF
--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/DeleteHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/DeleteHandler.java
@@ -25,8 +25,7 @@ public class DeleteHandler extends BaseHandlerStd {
         this.logger = logger;
         ResourceModel model = request.getDesiredResourceState();
         // STEP 1.0 [initialize a proxy context]
-        ProgressEvent<ResourceModel, CallbackContext> deleteProgressEvent = proxy
-            .initiate("AWS-CodeArtifact-Domain::Delete", proxyClient, model, callbackContext)
+        return proxy.initiate("AWS-CodeArtifact-Domain::Delete", proxyClient, model, callbackContext)
             // STEP 1.1 [construct a body of a request]
             .translateToServiceRequest(Translator::translateToDeleteRequest)
             // STEP 1.2 [make an api call]
@@ -54,12 +53,8 @@ public class DeleteHandler extends BaseHandlerStd {
             })
             // STEP 2.3 [Stabilize to check if the resource got deleted]
             .stabilize((deleteDomainRequest, deleteDomainResponse, proxyInvocation, resourceModel, context) -> !doesDomainExist(model, proxyClient))
-            .success();
-
-
-        // according to the ResourceHandler contract we must not return the model in the response
-        deleteProgressEvent.setResourceModel(null);
-        return deleteProgressEvent;
+            // according to the ResourceHandler contract we must not return the model in the response
+            .done((awsRequest, response, client, resourceModel, context) -> ProgressEvent.success(null, context));
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Making this the same as Repository DeleteHandler.java. This was causing intermintent ISE's



**Testing**


Ran locally with same, stabilization worked as expected
```
2020-10-05 16:11:29 127.0.0.1 - - [05/Oct/2020 16:11:29] "POST /2015-03-31/functions/TypeFunction/invocations HTTP/1.1" 200 -
Invoking software.amazon.codeartifact.domain.HandlerWrapper::handleRequest (java8)
Decompressing /Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-domain/target/aws-codeartifact-domain-handler-1.0-SNAPSHOT.jar

Fetching lambci/lambda:java8 Docker container image......
Mounting /private/var/folders/n_/7tmz09ds2gv06hqgr5ry6sr8n8z_lw/T/tmpx0klijp2 as /var/task:ro,delegated inside runtime container
START RequestId: 881e20ef-3f65-174f-ac68-30cb07ec0b52 Version: $LATEST
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[DELETE] invoking handler...
{"apiRequest": {"requestId": "329110a0-23d5-45c8-865c-72bdfeaf5df4", "requestName": "DescribeDomainRequest"}}
{"apiRequest": {"requestId": "65b84715-2cf3-4de5-86bc-952cb243b103", "requestName": "DeleteDomainRequest"}}
AWS::CodeArtifact::Domain successfully deleted.
Failed to execute remote function: {Domain not found. Domain 'domain-fas1' owned by account '946525001030' does not exist. (Service: Codeartifact, Status Code: 404, Request ID: ebfdc0a9-c6a8-4ae4-aa23-d43d4844b3f0, Extended Request ID: null)}
[DELETE] handler invoked
Handler returned SUCCESS
```



Also re-ran contract tests.

```
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.7.8, pytest-6.1.0, py-1.9.0, pluggy-0.13.1 -- /usr/local/opt/python@3.7/bin/python3.7
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-domain/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workplace/aws-cloudformation-resource-providers-codeartifact/aws-codeartifact-domain, configfile: ../../../../../private/var/folders/n_/7tmz09ds2gv06hqgr5ry6sr8n8z_lw/T/pytest_8so5_piy.ini
plugins: hypothesis-5.36.2, localserver-0.5.0, random-order-1.0.4
collected 16 items

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                    [ 12%]
handler_create.py::contract_create_duplicate SKIPPED                                                                                                                                                 [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                               [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                               [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                       [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                       [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                     [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                     [ 56%]
handler_delete.py::contract_delete_create SKIPPED                                                                                                                                                    [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                  [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                 [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                               [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                               [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                               [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                              [100%]

================================================================================ 14 passed, 2 skipped in 1061.14s (0:17:41) ================================================================================
```






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
