### PR TITLE
Adding a user-agent prefix

### DIFF
--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ClientBuilder.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/ClientBuilder.java
@@ -1,11 +1,20 @@
 package software.amazon.codeartifact.domain;
 
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
 public class ClientBuilder {
+  private static final String CFN_USER_AGENT_PREFIX = "aws-cloudformation-resource-handlers";
+
   public static CodeartifactClient getClient() {
     return CodeartifactClient.builder()
+        .overrideConfiguration(
+            ClientOverrideConfiguration.builder()
+                .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, CFN_USER_AGENT_PREFIX)
+                .build()
+        )
         .httpClient(LambdaWrapper.HTTP_CLIENT)
         .build();
   }

--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ClientBuilder.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/ClientBuilder.java
@@ -1,11 +1,20 @@
 package software.amazon.codeartifact.repository;
 
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
 public class ClientBuilder {
+  private static final String CFN_USER_AGENT_PREFIX = "aws-cloudformation-resource-handlers";
+
   public static CodeartifactClient getClient() {
     return CodeartifactClient.builder()
+        .overrideConfiguration(
+            ClientOverrideConfiguration.builder()
+                .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, CFN_USER_AGENT_PREFIX)
+                .build()
+        )
         .httpClient(LambdaWrapper.HTTP_CLIENT)
         .build();
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Checked user agent when testing and there was indeed a prefix in the userAgent

`aws-cloudformation-resource-handlers, aws-sdk-java/2.13.55`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
