### PR TITLE
Adding isCreated to callback context to allow for retries

### DIFF
--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CallbackContext.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CallbackContext.java
@@ -7,5 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
-    private boolean isCreated;
+    private boolean isCreated = false;
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CallbackContext.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    private boolean isCreated;
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
@@ -45,6 +45,7 @@ public class CreateHandler extends BaseHandlerStd {
     ) {
         CallbackContext callbackContext = progress.getCallbackContext();
 
+        logger.log(String.format("isCreatedFlag: %s", callbackContext.isCreated()));
         if (callbackContext.isCreated()) {
             // This happens when handler gets called again during callback delay or the handler is retrying
             // after domain was created already. This will prevent 409s on retry.

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
@@ -43,10 +43,19 @@ public class CreateHandler extends BaseHandlerStd {
         ResourceHandlerRequest<ResourceModel> request,
         ProxyClient<CodeartifactClient> proxyClient
     ) {
+        CallbackContext callbackContext = progress.getCallbackContext();
+
+        if (callbackContext.isCreated()) {
+            // This happens when handler gets called again during callback delay or the handler is retrying
+            // after repository was created already. This will prevent 409s on retry.
+            logger.log("Domain was already created, will not call CreateDomain again.");
+            return ProgressEvent.progress(progress.getResourceModel(), callbackContext);
+        }
+
         return proxy.initiate("AWS-CodeArtifact-Domain::Create", proxyClient,progress.getResourceModel(), progress.getCallbackContext())
             .translateToServiceRequest(Translator::translateToCreateRequest)
             .makeServiceCall((awsRequest, client) -> createDomainSdkCall(progress, client, awsRequest))
-            .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client))
+            .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client, callbackContext))
             .progress();
     }
 
@@ -73,7 +82,8 @@ public class CreateHandler extends BaseHandlerStd {
 
     private boolean isStabilized(
         final ResourceModel model,
-        final ProxyClient<CodeartifactClient> proxyClient
+        final ProxyClient<CodeartifactClient> proxyClient,
+        CallbackContext callbackContext
     ) {
         DescribeDomainResponse describeDomainResponse = proxyClient.injectCredentialsAndInvokeV2(
             Translator.translateToReadRequest(model), proxyClient.client()::describeDomain);
@@ -87,6 +97,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         if (domainStatus.equals(Constants.ACTIVE_STATUS)) {
             logger.log(String.format("%s successfully stabilized.", ResourceModel.TYPE_NAME));
+            callbackContext.setCreated(true);
             return true;
         }
 

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
@@ -47,7 +47,7 @@ public class CreateHandler extends BaseHandlerStd {
 
         if (callbackContext.isCreated()) {
             // This happens when handler gets called again during callback delay or the handler is retrying
-            // after repository was created already. This will prevent 409s on retry.
+            // after domain was created already. This will prevent 409s on retry.
             logger.log("Domain was already created, will not call CreateDomain again.");
             return ProgressEvent.progress(progress.getResourceModel(), callbackContext);
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Setting `isCreated` flag when domain is created so that if the handler retries for any reason, we don't get a 409. The flag state gets preserved if the handler set it and it gets called again.


**Testing**
Ran lambda locally with a context delay to force a retry and the retry succeeded without a 409.

```
[CREATE] invoking handler...
Domain was already created, will not call CreateDomain again.
AWS::CodeArtifact::Domain read handler is being invoked
AWS::CodeArtifact::Domain describeDomain is being invoked
{"apiRequest": {"requestId": "1f39dc8d-c2c2-4313-ba69-b1e3a770d574", "requestName": "DescribeDomainRequest"}}
AWS::CodeArtifact::Domain has successfully been read.
AWS::CodeArtifact::Domain getDomainPolicy is being invoked
Failed to execute remote function: {No policy found for (domain): (domain-retried) (Service: Codeartifact, Status Code: 404, Request ID: a69ecfec-53c2-4faa-bbd9-adf419b985c9, Extended Request ID: null)}
Domain policy of AWS::CodeArtifact::Domain has successfully been read.
[CREATE] handler invoked
Handler returned SUCCESS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
