### PR TITLE
Adding callback context delay to return in-progress event with primar…

### DIFF
--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CallbackContext.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CallbackContext.java
@@ -7,5 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
-    private boolean isCreated = false;
+    private boolean isCreated;
 }

--- a/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
+++ b/aws-codeartifact-domain/src/main/java/software/amazon/codeartifact/domain/CreateHandler.java
@@ -14,6 +14,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 
 public class CreateHandler extends BaseHandlerStd {
+    private static final int CALLBACK_DELAY_SECONDS = 1;
     private Logger logger;
 
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -57,7 +58,7 @@ public class CreateHandler extends BaseHandlerStd {
             .translateToServiceRequest(Translator::translateToCreateRequest)
             .makeServiceCall((awsRequest, client) -> createDomainSdkCall(progress, client, awsRequest))
             .stabilize((awsRequest, awsResponse, client, model, context) -> isStabilized(model, client, callbackContext))
-            .progress();
+            .progress(CALLBACK_DELAY_SECONDS);
     }
 
     private CreateDomainResponse createDomainSdkCall(

--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/CreateHandlerTest.java
@@ -98,6 +98,11 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void handleRequest_simpleSuccess() {
         final CreateHandler handler = new CreateHandler();
 
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .arn(DOMAIN_ARN)
+            .build();
+
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .build();
@@ -112,7 +117,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domain(domainDescription)
             .build();
 
-        when(proxyClient.client().getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().describeDomain(any(DescribeDomainRequest.class))).thenReturn(describeDomainResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -122,16 +126,15 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(1);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
         verify(codeartifactClient).createDomain(any(CreateDomainRequest.class));
-        verify(codeartifactClient).getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class));
-        verify(codeartifactClient, times(2)).describeDomain(any(DescribeDomainRequest.class));
+        verify(codeartifactClient, times(1)).describeDomain(any(DescribeDomainRequest.class));
         verify(codeartifactClient, never()).putDomainPermissionsPolicy(any(PutDomainPermissionsPolicyRequest.class));
 
     }
@@ -182,6 +185,12 @@ public class CreateHandlerTest extends AbstractTestBase {
     public void handleRequest_simpleSuccess_withEncryptionKey() {
         final CreateHandler handler = new CreateHandler();
 
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .arn(DOMAIN_ARN)
+            .encryptionKey(ENCRYPTION_KEY_ARN)
+            .build();
+
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .encryptionKey(ENCRYPTION_KEY_ARN)
@@ -197,7 +206,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domain(domainDescription)
             .build();
 
-        when(proxyClient.client().getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class))).thenThrow(ResourceNotFoundException.class);
         when(proxyClient.client().describeDomain(any(DescribeDomainRequest.class))).thenReturn(describeDomainResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -207,8 +215,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(1);
         assertThat(response.getResourceModel()).isEqualTo(desiredOutputModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
@@ -217,9 +225,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         ArgumentCaptor<CreateDomainRequest> createDomainRequestArgumentCaptor = ArgumentCaptor.forClass(CreateDomainRequest.class);
 
         verify(codeartifactClient).createDomain(createDomainRequestArgumentCaptor.capture());
-        verify(codeartifactClient, times(2)).describeDomain(any(DescribeDomainRequest.class));
+        verify(codeartifactClient, times(1)).describeDomain(any(DescribeDomainRequest.class));
         verify(codeartifactClient, never()).putDomainPermissionsPolicy(any(PutDomainPermissionsPolicyRequest.class));
-        verify(codeartifactClient).getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class));
 
         CreateDomainRequest createDomainRequestValue = createDomainRequestArgumentCaptor.getValue();
 
@@ -236,11 +243,6 @@ public class CreateHandlerTest extends AbstractTestBase {
             .permissionsPolicyDocument(TEST_POLICY_DOC)
             .build();
 
-        CreateDomainResponse createDomainResponse = CreateDomainResponse.builder()
-            .domain(domainDescription)
-            .build();
-
-        when(proxyClient.client().createDomain(any(CreateDomainRequest.class))).thenReturn(createDomainResponse);
         when(proxyClient.client().putDomainPermissionsPolicy(any(PutDomainPermissionsPolicyRequest.class))).thenReturn(
             PutDomainPermissionsPolicyResponse.builder().build()
         );
@@ -261,11 +263,13 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getDomainPermissionsPolicy(any(GetDomainPermissionsPolicyRequest.class))).thenReturn(getDomainPermissionsPolicyResponse);
         when(proxyClient.client().describeDomain(any(DescribeDomainRequest.class))).thenReturn(describeDomainResponse);
 
+        CallbackContext callbackContext = new CallbackContext();
+        callbackContext.setCreated(true);
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
             .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, callbackContext, proxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -285,8 +289,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(codeartifactClient).createDomain(any(CreateDomainRequest.class));
-        verify(codeartifactClient, times(2)).describeDomain(any(DescribeDomainRequest.class));
+        verify(codeartifactClient, times(1)).describeDomain(any(DescribeDomainRequest.class));
 
         ArgumentCaptor<PutDomainPermissionsPolicyRequest> putDomainPermissionsPolicyRequestArgumentCaptor
             = ArgumentCaptor.forClass(PutDomainPermissionsPolicyRequest.class);


### PR DESCRIPTION
…y identifier.

*Issue #, if available:*

*Description of changes:*
+ CFN team suggest I do this prevent resource leaking. I had already did this for repositories for other reasons
+ I also removed `private boolean isCreated = false;` because I am concerned that we are overwriting this flag between invokations. This is only a guess since I haven't been able to reproduce the leaking, Repositories are not leaking at all and this flag is not set like this so I figured I'd give it a shot.

**Testing**
Submitted on my account and domain's created successfully. Also passed in a bad policydoc and it rolled back correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
