### PR TITLE
Fixing arn that's getting passed to UntagResource.

### DIFF
--- a/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
+++ b/aws-codeartifact-repository/src/main/java/software/amazon/codeartifact/repository/Translator.java
@@ -36,12 +36,14 @@ import software.amazon.awssdk.services.codeartifact.model.RepositoryDescription;
 import software.amazon.awssdk.services.codeartifact.model.RepositoryExternalConnectionInfo;
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
+import software.amazon.awssdk.services.codeartifact.model.Tag;
 import software.amazon.awssdk.services.codeartifact.model.TagResourceRequest;
 import software.amazon.awssdk.services.codeartifact.model.UntagResourceRequest;
 import software.amazon.awssdk.services.codeartifact.model.UpdateRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.UpstreamRepository;
 import software.amazon.awssdk.services.codeartifact.model.UpstreamRepositoryInfo;
 import software.amazon.awssdk.services.codeartifact.model.ValidationException;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
@@ -52,8 +54,6 @@ import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorExceptio
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.codeartifact.repository.ResourceModel.ResourceModelBuilder;
-import software.amazon.awssdk.services.codeartifact.model.Tag;
-import software.amazon.awssdk.utils.CollectionUtils;
 
 /**
  * This class is a centralized placeholder for
@@ -101,13 +101,14 @@ public class Translator {
       ResourceHandlerRequest<ResourceModel> request,
       List<Tag> tagsToRemove,
       String repositoryName,
-      String domainName
+      String domainName,
+      String domainOwner
   ) {
 
     String arn = ArnUtils.repoArn(
         request.getAwsPartition(),
         request.getRegion(),
-        request.getAwsAccountId(),
+        domainOwner,
         domainName,
         repositoryName)
         .arn();
@@ -127,10 +128,8 @@ public class Translator {
       List<Tag> tagsToAdd,
       String repositoryName,
       String domainName,
-      ResourceModel model
+      String domainOwner
   ) {
-
-    String domainOwner = model.getDomainOwner() == null ? request.getAwsAccountId() : model.getDomainOwner();
 
     String arn = ArnUtils.repoArn(
         request.getAwsPartition(),

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/AbstractTestBase.java
@@ -34,8 +34,8 @@ public class AbstractTestBase {
   protected static final String DOMAIN_OWNER = "12345";
   protected static final String ADMIN_ACCOUNT = "54321";
   protected static final String REPO_NAME = "test-repo-name";
-  protected static final String REPO_ARN = String.format("arn:aws:codeartifact:%s:%s:repository/%s/%s",
-      REGION, DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
+  protected static final String REPO_ARN_WITH_DOMAIN_OWNER = getExpectedRepoArn(REGION, DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
+
   protected static final Map<String, Object> TEST_POLICY_DOC_0 = Collections.singletonMap("key0", "value0");
   protected static final Map<String, Object> TEST_POLICY_DOC_1 = Collections.singletonMap("key1", "value1");
 
@@ -108,6 +108,17 @@ public class AbstractTestBase {
         return sdkClient;
       }
     };
+  }
+
+
+  protected static String getExpectedRepoArn(
+      String region,
+      String domainOwner,
+      String domainName,
+      String repoName
+  ) {
+    return String.format("arn:aws:codeartifact:%s:%s:repository/%s/%s",
+        region, domainOwner, domainName, repoName);
   }
 
   protected void assertSuccess(

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/CreateHandlerTest.java
@@ -98,7 +98,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -112,7 +112,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -157,7 +157,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -206,7 +206,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .tags(RESOURCE_MODEL_TAGS)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -219,7 +219,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -280,7 +280,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -294,7 +294,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -341,7 +341,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
             .build();
@@ -349,7 +349,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .upstreams(
                 UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_0).build(),
@@ -400,7 +400,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -412,7 +412,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -481,7 +481,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(
                 Collections.singletonList(
@@ -500,7 +500,7 @@ public class CreateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .externalConnections(Collections.singletonList(NPM_EC))
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -546,7 +546,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/DeleteHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/DeleteHandlerTest.java
@@ -22,7 +22,6 @@ import software.amazon.awssdk.services.codeartifact.model.AccessDeniedException;
 import software.amazon.awssdk.services.codeartifact.model.ConflictException;
 import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DeleteRepositoryResponse;
-import software.amazon.awssdk.services.codeartifact.model.DescribeDomainRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryRequest;
 import software.amazon.awssdk.services.codeartifact.model.DescribeRepositoryResponse;
 import software.amazon.awssdk.services.codeartifact.model.InternalServerException;
@@ -56,7 +55,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
     private final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
         .name(REPO_NAME)
         .administratorAccount(ADMIN_ACCOUNT)
-        .arn(REPO_ARN)
+        .arn(REPO_ARN_WITH_DOMAIN_OWNER)
         .description(DESCRIPTION)
         .domainOwner(DOMAIN_OWNER)
         .domainName(DOMAIN_NAME)

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/ReadHandlerTest.java
@@ -60,7 +60,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     private final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
         .name(REPO_NAME)
         .administratorAccount(ADMIN_ACCOUNT)
-        .arn(REPO_ARN)
+        .arn(REPO_ARN_WITH_DOMAIN_OWNER)
         .description(DESCRIPTION)
         .domainOwner(DOMAIN_OWNER)
         .domainName(DOMAIN_NAME)
@@ -75,7 +75,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     private final ResourceModel desiredOutputModel = ResourceModel.builder()
         .domainName(DOMAIN_NAME)
         .domainOwner(DOMAIN_OWNER)
-        .arn(REPO_ARN)
+        .arn(REPO_ARN_WITH_DOMAIN_OWNER)
         .repositoryName(REPO_NAME)
         .name(REPO_NAME)
         .description(DESCRIPTION)
@@ -114,7 +114,7 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
-            .logicalResourceIdentifier(REPO_ARN)
+            .logicalResourceIdentifier(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -139,7 +139,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         final ResourceModel desiredOutputModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
             .name(REPO_NAME)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
@@ -164,7 +164,7 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
-            .logicalResourceIdentifier(REPO_ARN)
+            .logicalResourceIdentifier(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -188,7 +188,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         final ReadHandler handler = new ReadHandler();
 
         ResourceModel model = ResourceModel.builder()
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -200,7 +200,7 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
-            .logicalResourceIdentifier(REPO_ARN)
+            .logicalResourceIdentifier(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -238,7 +238,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         final ResourceModel desiredOutputModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .tags(RESOURCE_MODEL_TAGS)
             .repositoryName(REPO_NAME)
             .name(REPO_NAME)

--- a/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
+++ b/aws-codeartifact-repository/src/test/java/software/amazon/codeartifact/repository/UpdateHandlerTest.java
@@ -68,7 +68,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
         .name(REPO_NAME)
         .administratorAccount(ADMIN_ACCOUNT)
-        .arn(REPO_ARN)
+        .arn(REPO_ARN_WITH_DOMAIN_OWNER)
         .description(DESCRIPTION)
         .domainOwner(DOMAIN_OWNER)
         .domainName(DOMAIN_NAME)
@@ -104,7 +104,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -155,7 +155,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .permissionsPolicyDocument(TEST_POLICY_DOC_0)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -205,7 +205,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -244,7 +244,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .upstreams(
                 UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_0).build(),
                 UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_1).build()
@@ -259,7 +259,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
             .build();
@@ -304,7 +304,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -315,7 +315,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -371,7 +371,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(
                 Collections.singletonList(
@@ -390,7 +390,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .externalConnections(Collections.singletonList(NPM_EC))
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -439,7 +439,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
             .build();
@@ -449,7 +449,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(Collections.singletonList(NPM_EC))
             .build();
@@ -457,7 +457,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .externalConnections(
                 Collections.singletonList(
                     RepositoryExternalConnectionInfo.builder()
@@ -525,7 +525,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -533,7 +533,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(Collections.singletonList(NPM_EC))
             .build();
@@ -541,7 +541,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(
                 Collections.singletonList(
@@ -596,7 +596,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -604,7 +604,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(Collections.singletonList(NPM_EC))
             .build();
@@ -619,7 +619,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(
                 Collections.singletonList(
@@ -669,7 +669,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .externalConnections(Collections.singletonList(NPM_EC))
             .description(DESCRIPTION)
             .build();
@@ -679,7 +679,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .upstreams(UPSTREAMS)
             .description(DESCRIPTION)
             .build();
@@ -687,7 +687,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .upstreams(
                 UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_0).build(),
                 UpstreamRepositoryInfo.builder().repositoryName(UPSTREAM_1).build()
@@ -755,7 +755,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(
                 Collections.singletonList(
@@ -773,7 +773,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .externalConnections(Collections.singletonList(NPM_EC))
             .description(DESCRIPTION)
             .build();
@@ -785,7 +785,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .externalConnections(Collections.singletonList(NPM_EC))
 
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
@@ -833,14 +833,14 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
             .externalConnections(Collections.singletonList(NPM_EC))
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .build();
 
         final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .externalConnections(
                 Collections.singletonList(
@@ -914,7 +914,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_addTags() throws JsonProcessingException {
+    public void handleRequest_addTags_withDomainOwnerInTemplate_adminAccountIsDifferent() throws JsonProcessingException {
         final UpdateHandler handler = new UpdateHandler();
 
         final ResourceModel model = ResourceModel.builder()
@@ -929,8 +929,20 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
+            .build();
+
+        // expected Arn domainOwner should be with the passed in domainOwner from the template
+        String expectedRepoArn = getExpectedRepoArn(REGION, DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
+
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(expectedRepoArn)
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -942,7 +954,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceTags(DESIRED_TAGS_MAP)
             .awsPartition(PARTITION)
-            .awsAccountId(DOMAIN_OWNER)
+            .awsAccountId(ADMIN_ACCOUNT)
             .region(REGION)
             .desiredResourceState(model)
             .previousResourceState(resourceModel(null))
@@ -952,15 +964,22 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         assertSuccess(response, desiredOutputModel);
 
+        ArgumentCaptor<TagResourceRequest> tagResourceCaptor
+            = ArgumentCaptor.forClass(TagResourceRequest.class);
+
         verify(codeartifactClient).describeRepository(any(DescribeRepositoryRequest.class));
         verify(codeartifactClient).getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class));
         verify(codeartifactClient).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(codeartifactClient, never()).putRepositoryPermissionsPolicy(any(PutRepositoryPermissionsPolicyRequest.class));
-        verify(codeartifactClient).tagResource(any(TagResourceRequest.class));
+        verify(codeartifactClient).tagResource(tagResourceCaptor.capture());
+
+        TagResourceRequest capturedRequest = tagResourceCaptor.getValue();
+
+        assertThat(capturedRequest.resourceArn()).isEqualTo(expectedRepoArn);
     }
 
     @Test
-    public void handleRequest_addTags_withOutDomainOwner() throws JsonProcessingException {
+    public void handleRequest_addTags_withOutDomainOwnerInTemplate() throws JsonProcessingException {
         final UpdateHandler handler = new UpdateHandler();
 
         final ResourceModel model = ResourceModel.builder()
@@ -974,13 +993,25 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .repositoryName(REPO_NAME)
             .build();
 
+        // expected Arn domainOwner should be with the admin account id from the request
+        String expectedRepoArn = getExpectedRepoArn(REGION, ADMIN_ACCOUNT, DOMAIN_NAME, REPO_NAME);
+
         final ResourceModel desiredOutputModel = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(expectedRepoArn)
             .description(DESCRIPTION)
+            .build();
+
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(expectedRepoArn)
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
             .build();
 
         DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
@@ -992,7 +1023,66 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceTags(DESIRED_TAGS_MAP)
             .awsPartition(PARTITION)
-            .awsAccountId(DOMAIN_OWNER)
+            .awsAccountId(ADMIN_ACCOUNT)
+            .region(REGION)
+            .desiredResourceState(model)
+            .previousResourceState(previousModel)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertSuccess(response, desiredOutputModel);
+
+        ArgumentCaptor<TagResourceRequest> tagResourceCaptor
+            = ArgumentCaptor.forClass(TagResourceRequest.class);
+
+        verify(codeartifactClient).describeRepository(any(DescribeRepositoryRequest.class));
+        verify(codeartifactClient).getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class));
+        verify(codeartifactClient).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(codeartifactClient, never()).putRepositoryPermissionsPolicy(any(PutRepositoryPermissionsPolicyRequest.class));
+        verify(codeartifactClient).tagResource(tagResourceCaptor.capture());
+
+        TagResourceRequest capturedRequest = tagResourceCaptor.getValue();
+
+        // expected Arn domainOwner should be with the admin account id from the request
+        assertThat(capturedRequest.resourceArn()).isEqualTo(expectedRepoArn);
+    }
+
+    @Test
+    public void handleRequest_removeTags_withDomainOwnerInTemplate_adminAccountIsDifferent() throws JsonProcessingException {
+        final UpdateHandler handler = new UpdateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .repositoryName(REPO_NAME)
+            .build();
+
+        ResourceModel previousModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .repositoryName(REPO_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .build();
+
+        final ResourceModel desiredOutputModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .domainOwner(DOMAIN_OWNER)
+            .name(REPO_NAME)
+            .repositoryName(REPO_NAME)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
+            .description(DESCRIPTION)
+            .build();
+
+        DescribeRepositoryResponse describeRepositoryResponse = DescribeRepositoryResponse.builder()
+            .repository(repositoryDescription)
+            .build();
+
+        when(proxyClient.client().describeRepository(any(DescribeRepositoryRequest.class))).thenReturn(describeRepositoryResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .previousResourceTags(DESIRED_TAGS_MAP)
+            .awsPartition(PARTITION)
+            .awsAccountId(ADMIN_ACCOUNT)
             .region(REGION)
             .desiredResourceState(model)
             .previousResourceState(previousModel)
@@ -1006,17 +1096,44 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(codeartifactClient).getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class));
         verify(codeartifactClient).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(codeartifactClient, never()).putRepositoryPermissionsPolicy(any(PutRepositoryPermissionsPolicyRequest.class));
-        verify(codeartifactClient).tagResource(any(TagResourceRequest.class));
+
+
+        ArgumentCaptor<UntagResourceRequest> untagResourceCaptor
+            = ArgumentCaptor.forClass(UntagResourceRequest.class);
+
+        verify(codeartifactClient).untagResource(untagResourceCaptor.capture());
+
+        UntagResourceRequest capturedRequest = untagResourceCaptor.getValue();
+
+        // expected Arn domainOwner should be with the passed in domainOwner from the template
+        String expectedRepoArn = getExpectedRepoArn(REGION, DOMAIN_OWNER, DOMAIN_NAME, REPO_NAME);
+        assertThat(capturedRequest.resourceArn()).isEqualTo(expectedRepoArn);
     }
 
     @Test
-    public void handleRequest_removeTags() throws JsonProcessingException {
+    public void handleRequest_removeTags_withoutDomainOwnerInTemplate() throws JsonProcessingException {
         final UpdateHandler handler = new UpdateHandler();
 
         final ResourceModel model = ResourceModel.builder()
             .domainName(DOMAIN_NAME)
-            .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
+            .build();
+
+        ResourceModel previousModel = ResourceModel.builder()
+            .domainName(DOMAIN_NAME)
+            .repositoryName(REPO_NAME)
+            .build();
+
+        // expected Arn domainOwner should be with the admin account id from the request
+        String expectedRepoArn = getExpectedRepoArn(REGION, ADMIN_ACCOUNT, DOMAIN_NAME, REPO_NAME);
+
+        final RepositoryDescription repositoryDescription = RepositoryDescription.builder()
+            .name(REPO_NAME)
+            .administratorAccount(ADMIN_ACCOUNT)
+            .arn(expectedRepoArn)
+            .description(DESCRIPTION)
+            .domainOwner(DOMAIN_OWNER)
+            .domainName(DOMAIN_NAME)
             .build();
 
         final ResourceModel desiredOutputModel = ResourceModel.builder()
@@ -1024,7 +1141,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainOwner(DOMAIN_OWNER)
             .name(REPO_NAME)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(expectedRepoArn)
             .description(DESCRIPTION)
             .build();
 
@@ -1037,28 +1154,40 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceTags(DESIRED_TAGS_MAP)
             .awsPartition(PARTITION)
-            .awsAccountId(DOMAIN_OWNER)
+            .awsAccountId(ADMIN_ACCOUNT)
             .region(REGION)
             .desiredResourceState(model)
-            .previousResourceState(resourceModel(null))
+            .previousResourceState(previousModel)
             .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertSuccess(response, desiredOutputModel);
 
+        ArgumentCaptor<UntagResourceRequest> untagResourceCaptor
+            = ArgumentCaptor.forClass(UntagResourceRequest.class);
+
+        verify(codeartifactClient).untagResource(untagResourceCaptor.capture());
+
+
         verify(codeartifactClient).describeRepository(any(DescribeRepositoryRequest.class));
         verify(codeartifactClient).getRepositoryPermissionsPolicy(any(GetRepositoryPermissionsPolicyRequest.class));
         verify(codeartifactClient).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(codeartifactClient, never()).putRepositoryPermissionsPolicy(any(PutRepositoryPermissionsPolicyRequest.class));
-        verify(codeartifactClient).untagResource(any(UntagResourceRequest.class));
+
+        verify(codeartifactClient).untagResource(untagResourceCaptor.capture());
+
+        UntagResourceRequest capturedRequest = untagResourceCaptor.getValue();
+        assertThat(capturedRequest.resourceArn()).isEqualTo(expectedRepoArn);
     }
+
+
 
     RepositoryDescription RepoInfoWithOutExternalConnections() {
         return RepositoryDescription.builder()
             .name(REPO_NAME)
             .administratorAccount(ADMIN_ACCOUNT)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .description(DESCRIPTION)
             .domainOwner(DOMAIN_OWNER)
             .domainName(DOMAIN_NAME)
@@ -1070,7 +1199,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
             .domainName(DOMAIN_NAME)
             .domainOwner(DOMAIN_OWNER)
             .repositoryName(REPO_NAME)
-            .arn(REPO_ARN)
+            .arn(REPO_ARN_WITH_DOMAIN_OWNER)
             .externalConnections(Collections.singletonList(PYPI_EC))
             .description(DESCRIPTION)
             .build();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
+ UnTagResource was incorrectly *not* taking in the DomainOwner from the CFN template and always using the request's caller accountId
+ Made unit test slightly more robust and asserting on the arn passed into the request

*Testing*
Did `cfn submit` on my own account and successfully repro the issue and fixed it with this code change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
