### PR TITLE
Changing exception type on deleting domain with repositories.

### DIFF
--- a/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/DeleteHandlerTest.java
+++ b/aws-codeartifact-domain/src/test/java/software/amazon/codeartifact/domain/DeleteHandlerTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -30,9 +31,8 @@ import software.amazon.awssdk.services.codeartifact.model.InternalServerExceptio
 import software.amazon.awssdk.services.codeartifact.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.codeartifact.model.ServiceQuotaExceededException;
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -132,13 +132,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
             .logicalResourceIdentifier(DOMAIN_ARN)
             .build();
 
-        try {
-            final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-            fail("Expected Exception");
-        } catch (CfnResourceConflictException e) {
-            //Expected
-
-        }
+        assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(codeartifactClient).deleteDomain(any(DeleteDomainRequest.class));
         verify(codeartifactClient, times(1)).describeDomain(any(DescribeDomainRequest.class));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Apparently this exception would cause the handlers to continuously retry and would emit internal failure metrics even thought this is more of a user error. Changing this to throw `CfnInvalidRequestException` instead


**Testing**
`cfn submit`  and observed the new error message:

```
Domain must contain 0 repositories before deletion (Service: Codeartifact, Status Code: 409, Request ID: 2d4eee90-712e-4eb5-b6f9-928c7145431b, Extended Request ID: null)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
