### PR TITLE
adding "additionalProperties" property to tagging schema

### DIFF
--- a/aws-codeartifact-domain/aws-codeartifact-domain.json
+++ b/aws-codeartifact-domain/aws-codeartifact-domain.json
@@ -23,7 +23,8 @@
       "required": [
         "Value",
         "Key"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/aws-codeartifact-repository/aws-codeartifact-repository.json
+++ b/aws-codeartifact-repository/aws-codeartifact-repository.json
@@ -23,7 +23,8 @@
       "required": [
         "Value",
         "Key"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {


### PR DESCRIPTION
Description of change:

Previously we did not have any schema validation for tagging. Hence, added "additionalProperties: false" so that all properties of type object are defined and no additional unknown property can be passed onto the cfn handlers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
